### PR TITLE
Fix linker error on FreeBSD >=10 (with Clang)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,7 +83,7 @@ set(QT_LIBRARIES Qt5::Widgets Qt5::Core Qt5::DBus Qt5::PrintSupport Qt5::X11Extr
 target_link_libraries(lximage-qt
     fm-qt
     ${QT_LIBRARIES}
-    ${EXIF_LIBRARIES}
+    ${EXIF_LDFLAGS}
     ${X11_LIBRARIES}
     ${XFIXES_LIBRARIES}
 )


### PR DESCRIPTION
I noticed, lximage-qt build fails with Clang (on FreeBSD > 10). Linker does not find -lexif even we explicite pass LDFLAGS variable.

Using EXIF_LDFLAGS (it adds all required linker flags) in target_link_libraries function fixes this issue.