### PR TITLE
Added more keyboard shortcuts

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -120,7 +120,7 @@ MainWindow::MainWindow():
   shortcut = new QShortcut(Qt::Key_Space, this);
   connect(shortcut, &QShortcut::activated, this, &MainWindow::on_actionNext_triggered);
   shortcut = new QShortcut(Qt::Key_Escape, this);
-  connect(shortcut, &QShortcut::activated, this, &MainWindow::onExitFullscreen);
+  connect(shortcut, &QShortcut::activated, this, &MainWindow::onKeyboardEscape);
 }
 
 MainWindow::~MainWindow() {
@@ -969,9 +969,11 @@ void MainWindow::onContextMenu(QPoint pos) {
   contextMenu_->exec(ui.view->mapToGlobal(pos));
 }
 
-void MainWindow::onExitFullscreen() {
+void MainWindow::onKeyboardEscape() {
   if(isFullScreen())
-    showNormal();
+    ui.actionFullScreen->trigger(); // will also "uncheck" the menu entry
+  else
+    on_actionClose_triggered();
 }
 
 void MainWindow::onThumbnailSelChanged(const QItemSelection& selected, const QItemSelection& /*deselected*/) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -110,10 +110,14 @@ MainWindow::MainWindow():
   contextMenu_->addAction(ui.actionFlipVertical);
   contextMenu_->addAction(ui.actionFlipVertical);
 
-  // create shortcuts
+  // create keyboard shortcuts
   QShortcut* shortcut = new QShortcut(Qt::Key_Left, this);
   connect(shortcut, &QShortcut::activated, this, &MainWindow::on_actionPrevious_triggered);
+  shortcut = new QShortcut(Qt::Key_Backspace, this);
+  connect(shortcut, &QShortcut::activated, this, &MainWindow::on_actionPrevious_triggered);
   shortcut = new QShortcut(Qt::Key_Right, this);
+  connect(shortcut, &QShortcut::activated, this, &MainWindow::on_actionNext_triggered);
+  shortcut = new QShortcut(Qt::Key_Space, this);
   connect(shortcut, &QShortcut::activated, this, &MainWindow::on_actionNext_triggered);
   shortcut = new QShortcut(Qt::Key_Escape, this);
   connect(shortcut, &QShortcut::activated, this, &MainWindow::onExitFullscreen);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -120,7 +120,7 @@ private Q_SLOTS:
   void on_actionZoomFit_triggered();
 
   void onContextMenu(QPoint pos);
-  void onExitFullscreen();
+  void onKeyboardEscape();
 
   void onThumbnailSelChanged(const QItemSelection & selected, const QItemSelection & deselected);
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -309,6 +309,9 @@
    <property name="text">
     <string>&amp;Rotate Clockwise</string>
    </property>
+   <property name="shortcut">
+    <string>R</string>
+   </property>
   </action>
   <action name="actionRotateCounterclockwise">
    <property name="icon">
@@ -317,6 +320,9 @@
    </property>
    <property name="text">
     <string>Rotate &amp;Counterclockwise</string>
+   </property>
+   <property name="shortcut">
+    <string>L</string>
    </property>
   </action>
   <action name="actionPreferences">
@@ -372,6 +378,9 @@
    <property name="text">
     <string>Flip &amp;Horizontally</string>
    </property>
+   <property name="shortcut">
+    <string>H</string>
+   </property>
   </action>
   <action name="actionScreenshot">
    <property name="icon">
@@ -396,6 +405,9 @@
   <action name="actionFlipVertical">
    <property name="text">
     <string>Flip &amp;Vertically</string>
+   </property>
+   <property name="shortcut">
+    <string>V</string>
    </property>
   </action>
   <action name="actionPaste">
@@ -437,6 +449,9 @@
    </property>
    <property name="text">
     <string>Show Thumbnails</string>
+   </property>
+   <property name="shortcut">
+    <string>T</string>
    </property>
   </action>
   <action name="actionFileProperties">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -15,15 +15,23 @@
   </property>
   <property name="windowIcon">
    <iconset theme="lximage-qt">
-    <normaloff/>
-   </iconset>
+    <normaloff>.</normaloff>.</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QHBoxLayout" name="horizontalLayout">
     <property name="spacing">
      <number>0</number>
     </property>
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item>
@@ -47,7 +55,7 @@
      <x>0</x>
      <y>0</y>
      <width>543</width>
-     <height>23</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -155,8 +163,7 @@
   <action name="actionAbout">
    <property name="icon">
     <iconset theme="help-about">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;About</string>
@@ -165,8 +172,7 @@
   <action name="actionOpenFile">
    <property name="icon">
     <iconset theme="document-open">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;Open File</string>
@@ -178,8 +184,7 @@
   <action name="actionSave">
    <property name="icon">
     <iconset theme="document-save">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;Save</string>
@@ -191,8 +196,7 @@
   <action name="actionSaveAs">
    <property name="icon">
     <iconset theme="document-save-as">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Save &amp;As</string>
@@ -204,8 +208,7 @@
   <action name="actionClose">
    <property name="icon">
     <iconset theme="application-exit">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;Close</string>
@@ -217,8 +220,7 @@
   <action name="actionZoomIn">
    <property name="icon">
     <iconset theme="zoom-in">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Zoom &amp;In</string>
@@ -230,8 +232,7 @@
   <action name="actionZoomOut">
    <property name="icon">
     <iconset theme="zoom-out">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Zoom &amp;Out</string>
@@ -243,8 +244,7 @@
   <action name="actionCopy">
    <property name="icon">
     <iconset theme="edit-copy">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;Copy to Clipboard</string>
@@ -253,8 +253,7 @@
   <action name="actionNext">
    <property name="icon">
     <iconset theme="go-next">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Next File</string>
@@ -269,8 +268,7 @@
   <action name="actionPrevious">
    <property name="icon">
     <iconset theme="go-previous">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Previous File</string>
@@ -285,8 +283,7 @@
   <action name="actionOriginalSize">
    <property name="icon">
     <iconset theme="zoom-original">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Original Size</string>
@@ -298,8 +295,7 @@
   <action name="actionZoomFit">
    <property name="icon">
     <iconset theme="zoom-fit-best">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;Fit</string>
@@ -308,8 +304,7 @@
   <action name="actionRotateClockwise">
    <property name="icon">
     <iconset theme="object-rotate-right">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;Rotate Clockwise</string>
@@ -318,8 +313,7 @@
   <action name="actionRotateCounterclockwise">
    <property name="icon">
     <iconset theme="object-rotate-left">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Rotate &amp;Counterclockwise</string>
@@ -341,8 +335,7 @@
   <action name="actionFirst">
    <property name="icon">
     <iconset theme="go-first">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>First File</string>
@@ -354,8 +347,7 @@
   <action name="actionLast">
    <property name="icon">
     <iconset theme="go-last">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Last File</string>
@@ -367,8 +359,7 @@
   <action name="actionNewWindow">
    <property name="icon">
     <iconset theme="document-new">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;New Window</string>
@@ -385,8 +376,7 @@
   <action name="actionScreenshot">
    <property name="icon">
     <iconset theme="camera-photo">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Capture Screenshot</string>
@@ -411,8 +401,7 @@
   <action name="actionPaste">
    <property name="icon">
     <iconset theme="edit-paste">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;Paste from Clipboard</string>
@@ -424,8 +413,7 @@
    </property>
    <property name="icon">
     <iconset theme="media-playback-start">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;Slide Show</string>
@@ -434,8 +422,7 @@
   <action name="actionDelete">
    <property name="icon">
     <iconset theme="edit-delete">
-     <normaloff/>
-    </iconset>
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>&amp;Delete</string>
@@ -459,7 +446,8 @@
   </action>
   <action name="actionOpenDirectory">
    <property name="icon">
-    <iconset theme="document-open"/>
+    <iconset theme="document-open">
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Open &amp;Directory</string>
@@ -470,7 +458,8 @@
   </action>
   <action name="actionUpload">
    <property name="icon">
-    <iconset theme="upload-media"/>
+    <iconset theme="upload-media">
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
     <string>Upload</string>


### PR DESCRIPTION
I add the following keyboard shortcuts in this PR:

- Esc -> exit
- h -> flip horizontally
- r -> rotate clockwise
- l -> rotate counter clockwise
- t -> show/hide thumbnails
- space -> next image
- backspace -> previous image

I did not implement showing/hiding the toolbar via a keyboard shortcut, because I did not find a simple way to do it. But maybe there is one, if someone points me into the right direction I will implement it. But I also think that hiding the toolbar via keyboard is not that often used.
Fixes #92 