### PR TITLE
Fix a FTBFS due to libfm header inclusion

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -27,7 +27,6 @@
 #include "imageview.h"
 #include <QImage>
 
-#include <libfm/fm-folder.h>
 #include <libfm-qt/foldermodel.h>
 #include <libfm-qt/proxyfoldermodel.h>
 #include <gio/gio.h>


### PR DESCRIPTION
lifm-qt no longer depends on libfm.