### PR TITLE
Removes local compile definition

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,6 @@ add_executable(lximage-qt
 add_definitions(
     -DLXIMAGE_DATA_DIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}/lximage-qt"
     -DLXIMAGE_VERSION="${LXIMAGE_VERSION}"
-    -DQT_NO_FOREACH
 )
 
 set(QT_LIBRARIES Qt5::Widgets Qt5::Network Qt5::Core Qt5::DBus Qt5::PrintSupport Qt5::X11Extras Qt5::Svg)


### PR DESCRIPTION
QT_NO_FOREACH is already part of LXQtCompilerSettings CMake module.