### PR TITLE
use XFIXES_LDFLAGS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,7 +91,7 @@ target_link_libraries(lximage-qt
     ${QT_LIBRARIES}
     ${EXIF_LIBRARIES}
     ${X11_LIBRARIES}
-    ${XFIXES_LIBRARIES}
+    ${XFIXES_LDFLAGS}
 )
 
 install(TARGETS lximage-qt RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
use XFIXES_LDFLAGS so Clang linker can find the libXfixes library (FreeBSD)