### PR TITLE
Add copy button to upload dialog

### DIFF
--- a/src/upload/uploaddialog.cpp
+++ b/src/upload/uploaddialog.cpp
@@ -17,7 +17,9 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include <QClipboard>
 #include <QComboBox>
+#include <QGuiApplication>
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QProgressBar>
@@ -65,6 +67,11 @@ void UploadDialog::on_actionButton_clicked()
     }
 }
 
+void UploadDialog::on_copyButton_clicked()
+{
+    QGuiApplication::clipboard()->setText(ui.linkLineEdit->text());
+}
+
 void UploadDialog::start()
 {
     // Attempt to open the file
@@ -87,6 +94,7 @@ void UploadDialog::start()
     // If the request completes, show the link to the user
     connect(mUpload, &Upload::completed, [this](const QString &url) {
         ui.linkLineEdit->setText(url);
+        ui.linkLineEdit->selectAll();
 
         mState = Completed;
         updateUi();
@@ -114,6 +122,7 @@ void UploadDialog::updateUi()
     ui.providerComboBox->setVisible(mState == SelectProvider);
     ui.progressBar->setVisible(mState == UploadInProgress);
     ui.linkLineEdit->setVisible(mState == Completed);
+    ui.copyButton->setVisible(mState == Completed);
 
     // Reset the progress bar to zero
     ui.progressBar->setValue(0);

--- a/src/upload/uploaddialog.h
+++ b/src/upload/uploaddialog.h
@@ -48,6 +48,7 @@ public:
 private Q_SLOTS:
 
     void on_actionButton_clicked();
+    void on_copyButton_clicked();
 
 private:
 

--- a/src/upload/uploaddialog.ui
+++ b/src/upload/uploaddialog.ui
@@ -33,6 +33,13 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="copyButton">
+       <property name="text">
+        <string>Copy</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -47,6 +54,13 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
This pull request adds a copy button to the upload dialog for easily copying the link to the clipboard:

![lximage-copy](https://user-images.githubusercontent.com/1253444/47771028-e59cc480-dc9e-11e8-820f-5f3ee0af9ac4.png)
