### PR TITLE
Bump minor version to 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(lximage-qt)
 include(GNUInstallDirs)
 
 set(MAJOR_VERSION 0)
-set(MINOR_VERSION 7)
+set(MINOR_VERSION 14)
 set(PATCH_VERSION 0)
 set(LXIMAGE_VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION})
 


### PR DESCRIPTION
Nice big bump to prevent conflicts with translations that are former built from
lxqt-l10n and have version 0.13.x