### PR TITLE
ui: rename user-visible 'toolBar_2', and hide it in full screen mode

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1008,6 +1008,7 @@ void MainWindow::changeEvent(QEvent* event) {
       ui.view->setFrameStyle(QFrame::NoFrame);
       ui.view->setBackgroundBrush(QBrush(app->settings().fullScreenBgColor()));
       ui.toolBar->hide();
+      ui.annotationsToolBar->hide();
       ui.statusBar->hide();
       if(thumbnailsDock_)
         thumbnailsDock_->hide();
@@ -1034,6 +1035,7 @@ void MainWindow::changeEvent(QEvent* event) {
       }
       ui.menubar->show();
       ui.toolBar->show();
+      ui.annotationsToolBar->show();
       ui.statusBar->show();
       if(thumbnailsDock_)
         thumbnailsDock_->show();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -172,7 +172,7 @@
   <widget class="QStatusBar" name="statusBar"/>
   <widget class="QToolBar" name="annotationsToolBar">
    <property name="windowTitle">
-    <string>toolBar_2</string>
+    <string>Annotations Toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>


### PR DESCRIPTION
Seeing 'toolBar_2' looks just a little bit odd in the context menu.  :]

I first went with 'Toolbar 2', but then I realised its name is already 'annotationsToolBar' elsewhere, so I decided to go with that instead.

I'm not sure if the intention was to not hide this one in full screen mode, so as to be able to annotate while in said mode.  I can de-select the toolbar, but the setting isn't remembered (and if it was remembered, it would probably be hidden when exiting full screen mode too, which might be weird).

That said, it would be nice to be able to remove, and keep them both bars removed via the preferences, or perhaps the view settings.
