### PR TITLE
Fix the file open string

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -201,7 +201,7 @@
      <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
-    <string>&amp;File</string>
+    <string>&amp;Open…</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>


### PR DESCRIPTION
File -> File don't make sense and is not consistent with nearly all other™
Software around (Inkscape, Gimp, LO, Geany and so on)

Should be Open… (with Ellipsis instead of three point). We should change
'...' to '…' projectwide, all people will hate us and esp. me, esp the translators,
but hey - we really should do that.