### PR TITLE
An option to show/hide annotations toolbar by default

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -96,6 +96,20 @@ MainWindow::MainWindow():
   if(settings.showThumbnails())
     setShowThumbnails(true);
 
+  ui.annotationsToolBar->setVisible(settings.isAnnotationsToolbarShown());
+  ui.actionAnnotations->setChecked(settings.isAnnotationsToolbarShown());
+  connect(ui.actionAnnotations, &QAction::triggered, [this](int checked) {
+    if(!isFullScreen()) { // annotations toolbar is hidden in fullscreen
+      ui.annotationsToolBar->setVisible(checked);
+    }
+  });
+  // annotations toolbar visibility can change in its context menu
+  connect(ui.annotationsToolBar, &QToolBar::visibilityChanged, [this](int visible) {
+    if(!isFullScreen()) { // annotations toolbar is hidden in fullscreen
+      ui.actionAnnotations->setChecked(visible);
+    }
+  });
+
   contextMenu_->addAction(ui.actionPrevious);
   contextMenu_->addAction(ui.actionNext);
   contextMenu_->addSeparator();
@@ -106,6 +120,7 @@ MainWindow::MainWindow():
   contextMenu_->addSeparator();
   contextMenu_->addAction(ui.actionSlideShow);
   contextMenu_->addAction(ui.actionFullScreen);
+  contextMenu_->addAction(ui.actionAnnotations);
   contextMenu_->addSeparator();
   contextMenu_->addAction(ui.actionRotateClockwise);
   contextMenu_->addAction(ui.actionRotateCounterclockwise);
@@ -1035,7 +1050,9 @@ void MainWindow::changeEvent(QEvent* event) {
       }
       ui.menubar->show();
       ui.toolBar->show();
-      ui.annotationsToolBar->show();
+      if(ui.actionAnnotations->isChecked()){
+          ui.annotationsToolBar->show();
+      }
       ui.statusBar->show();
       if(thumbnailsDock_)
         thumbnailsDock_->show();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -112,6 +112,7 @@
     <addaction name="actionFullScreen"/>
     <addaction name="actionSlideShow"/>
     <addaction name="separator"/>
+    <addaction name="actionAnnotations"/>
    </widget>
    <widget class="QMenu" name="menu_Edit">
     <property name="title">
@@ -602,6 +603,17 @@
    </property>
    <property name="toolTip">
     <string>Draw incrementing numbers</string>
+   </property>
+  </action>
+  <action name="actionAnnotations">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Annotations Toolbar</string>
+   </property>
+   <property name="toolTip">
+    <string>Annotations Toolbar</string>
    </property>
   </action>
  </widget>

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -38,6 +38,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   ui.bgColor->setColor(settings.bgColor());
   ui.fullScreenBgColor->setColor(settings.fullScreenBgColor());
   ui.slideShowInterval->setValue(settings.slideShowInterval());
+  ui.annotationBox->setChecked(settings.isAnnotationsToolbarShown());
 }
 
 PreferencesDialog::~PreferencesDialog() {
@@ -69,6 +70,7 @@ void PreferencesDialog::accept() {
   settings.setBgColor(ui.bgColor->color());
   settings.setFullScreenBgColor(ui.fullScreenBgColor->color());
   settings.setSlideShowInterval(ui.slideShowInterval->value());
+  settings.showAnnotationsToolbar(ui.annotationBox->isChecked());
 
   settings.save();
   QDialog::accept();

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -79,6 +79,13 @@
          </property>
         </widget>
        </item>
+       <item row="4" column="0" colspan="2">
+        <widget class="QCheckBox" name="annotationBox">
+         <property name="text">
+          <string>Show annotations toolbar by default</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -36,7 +36,8 @@ Settings::Settings():
   fixedWindowHeight_(480),
   lastWindowWidth_(640),
   lastWindowHeight_(480),
-  lastWindowMaximized_(false) {
+  lastWindowMaximized_(false),
+  showAnnotationsToolbar_(false) {
 }
 
 Settings::~Settings() {
@@ -59,6 +60,7 @@ bool Settings::load() {
   lastWindowHeight_ = settings.value("LastWindowHeight", 480).toInt();
   lastWindowMaximized_ = settings.value("LastWindowMaximized", false).toBool();
   rememberWindowSize_ = settings.value("RememberWindowSize", true).toBool();
+  showAnnotationsToolbar_ = settings.value("ShowAnnotationsToolbar", false).toBool();
   settings.endGroup();
 
   return true;
@@ -80,6 +82,7 @@ bool Settings::save() {
   settings.setValue("LastWindowHeight", lastWindowHeight_);
   settings.setValue("LastWindowMaximized", lastWindowMaximized_);
   settings.setValue("RememberWindowSize", rememberWindowSize_);
+  settings.setValue("ShowAnnotationsToolbar", showAnnotationsToolbar_);
   settings.endGroup();
 
   return true;

--- a/src/settings.h
+++ b/src/settings.h
@@ -145,6 +145,14 @@ public:
       lastWindowMaximized_ = lastWindowMaximized;
   }
 
+  bool isAnnotationsToolbarShown() const {
+    return showAnnotationsToolbar_;
+  }
+
+  void showAnnotationsToolbar(bool show) {
+    showAnnotationsToolbar_ = show;
+  }
+
 private:
   bool useFallbackIconTheme_;
   QColor bgColor_;
@@ -161,6 +169,7 @@ private:
   int lastWindowWidth_;
   int lastWindowHeight_;
   bool lastWindowMaximized_;
+  bool showAnnotationsToolbar_;
 };
 
 }


### PR DESCRIPTION
This patch hides it by default (because lximage-qt is an image *viewer*, not editor) but adds an option to Preferences to show it by default. It also adds an item to the View menu to show/hide it in the current window.