### PR TITLE
Optionally show image outline

### DIFF
--- a/src/imageview.h
+++ b/src/imageview.h
@@ -81,6 +81,8 @@ public:
     ToolNumber
   };
   void activateTool(Tool tool);
+  void showOutline(bool show);
+  void updateOutline();
 
 Q_SIGNALS:
   void fileDropped(const QString file);
@@ -114,6 +116,7 @@ private Q_SLOTS:
 private:
   GraphicsScene* scene_; // the topmost container of all graphic items
   QGraphicsRectItem* imageItem_; // the rect item used to draw the image
+  QGraphicsRectItem* outlineItem_; // the rect to draw the image outline
   QImage image_; // image to show
   QMovie *gifMovie_; // gif animation to show (should be deleted explicitly)
   QPixmap cachedPixmap_; // caching of current viewport content (high quality scaled image)
@@ -127,6 +130,7 @@ private:
   Tool currentTool; // currently selected tool
   QPoint startPoint; // starting point for the tool
   int nextNumber;
+  bool showOutline_;
 };
 
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -110,6 +110,7 @@ private Q_SLOTS:
   void on_actionUpload_triggered();
 
   void on_actionShowThumbnails_triggered(bool checked);
+  void on_actionShowOutline_triggered(bool checked);
   void on_actionShowExifData_triggered(bool checked);
   void on_actionFullScreen_triggered(bool checked);
   void on_actionSlideShow_triggered(bool checked);
@@ -142,7 +143,8 @@ private:
   void updateUI();
   void setModified(bool modified);
   QModelIndex indexFromPath(const Fm::FilePath & filePath);
-  QGraphicsItem* getGraphicsItem();
+  QGraphicsItem* getImageGraphicsItem();
+  QGraphicsItem* getOutlineGraphicsItem();
 
 private:
   Ui::MainWindow ui;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -107,6 +107,7 @@
     <addaction name="actionZoomFit"/>
     <addaction name="separator"/>
     <addaction name="actionShowThumbnails"/>
+    <addaction name="actionShowOutline"/>
     <addaction name="actionShowExifData"/>
     <addaction name="separator"/>
     <addaction name="actionFullScreen"/>
@@ -614,6 +615,20 @@
    </property>
    <property name="toolTip">
     <string>Annotations Toolbar</string>
+   </property>
+  </action>
+  <action name="actionShowOutline">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Outline</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Outline</string>
+   </property>
+   <property name="shortcut">
+    <string>O</string>
    </property>
   </action>
  </widget>

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -38,6 +38,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   ui.bgColor->setColor(settings.bgColor());
   ui.fullScreenBgColor->setColor(settings.fullScreenBgColor());
   ui.slideShowInterval->setValue(settings.slideShowInterval());
+  ui.oulineBox->setChecked(settings.isOutlineShown());
   ui.annotationBox->setChecked(settings.isAnnotationsToolbarShown());
 }
 
@@ -70,6 +71,7 @@ void PreferencesDialog::accept() {
   settings.setBgColor(ui.bgColor->color());
   settings.setFullScreenBgColor(ui.fullScreenBgColor->color());
   settings.setSlideShowInterval(ui.slideShowInterval->value());
+  settings.showOutline(ui.oulineBox->isChecked());
   settings.showAnnotationsToolbar(ui.annotationBox->isChecked());
 
   settings.save();

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -80,6 +80,13 @@
         </widget>
        </item>
        <item row="4" column="0" colspan="2">
+        <widget class="QCheckBox" name="oulineBox">
+         <property name="text">
+          <string>Show image outline by default</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
         <widget class="QCheckBox" name="annotationBox">
          <property name="text">
           <string>Show annotations toolbar by default</string>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -37,6 +37,7 @@ Settings::Settings():
   lastWindowWidth_(640),
   lastWindowHeight_(480),
   lastWindowMaximized_(false),
+  showOutline_(false),
   showAnnotationsToolbar_(false) {
 }
 
@@ -60,6 +61,7 @@ bool Settings::load() {
   lastWindowHeight_ = settings.value(QStringLiteral("LastWindowHeight"), 480).toInt();
   lastWindowMaximized_ = settings.value(QStringLiteral("LastWindowMaximized"), false).toBool();
   rememberWindowSize_ = settings.value(QStringLiteral("RememberWindowSize"), true).toBool();
+  showOutline_ = settings.value(QStringLiteral("ShowOutline"), false).toBool();
   showAnnotationsToolbar_ = settings.value(QStringLiteral("ShowAnnotationsToolbar"), false).toBool();
   settings.endGroup();
 
@@ -82,6 +84,7 @@ bool Settings::save() {
   settings.setValue(QStringLiteral("LastWindowHeight"), lastWindowHeight_);
   settings.setValue(QStringLiteral("LastWindowMaximized"), lastWindowMaximized_);
   settings.setValue(QStringLiteral("RememberWindowSize"), rememberWindowSize_);
+  settings.setValue(QStringLiteral("ShowOutline"), showOutline_);
   settings.setValue(QStringLiteral("ShowAnnotationsToolbar"), showAnnotationsToolbar_);
   settings.endGroup();
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -145,6 +145,14 @@ public:
       lastWindowMaximized_ = lastWindowMaximized;
   }
 
+  bool isOutlineShown() const {
+    return showOutline_;
+  }
+
+  void showOutline(bool show) {
+    showOutline_ = show;
+  }
+
   bool isAnnotationsToolbarShown() const {
     return showAnnotationsToolbar_;
   }
@@ -169,6 +177,7 @@ private:
   int lastWindowWidth_;
   int lastWindowHeight_;
   bool lastWindowMaximized_;
+  bool showOutline_;
   bool showAnnotationsToolbar_;
 };
 


### PR DESCRIPTION
Closes https://github.com/lxqt/lximage-qt/issues/196

It is useful for checking the space around an image/icon.

Also found and fixed a small hidden bug about showing next/previous image.