### PR TITLE
Prevent blurry images with HDPI

### DIFF
--- a/src/imageview.h
+++ b/src/imageview.h
@@ -102,6 +102,8 @@ private:
   QRect viewportToScene(const QRect& rect);
   QRect sceneToViewport(const QRectF& rect);
 
+  void drawOutline();
+
   void drawArrow(QPainter &painter,
                  const QPoint &start,
                  const QPoint &end,


### PR DESCRIPTION
Fixes https://github.com/lxqt/lximage-qt/issues/242

Previously, when Qt scale factor was greater than 1, (unscaled) images became blurry. This patch fixes the problem by setting the device pixel ratio of the image to that of the app and also by considering it in calculating sizes. In short, images are shown with their real sizes.

Also cleaned up the code for image outline and fixed a small issue in it.