### PR TITLE
Jump forward when the image is deleted/renamed

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -135,6 +135,7 @@ private Q_SLOTS:
   void onKeyboardEscape();
 
   void onThumbnailSelChanged(const QItemSelection & selected, const QItemSelection & deselected);
+  void onFilesRemoved(const Fm::FileInfoList& files);
 
   void onFileDropped(const QString path);
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/lximage-qt/issues/187

If there are other images, the next one will be shown (or the previous one if the last image is deleted); otherwise, a blank view will be shown (even when the image is renamed).