### PR TITLE
Made maximum number of recent files configurable

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -133,6 +133,7 @@ MainWindow::MainWindow():
   contextMenu_->addAction(ui.actionFlipVertical);
 
   // Open images when MRU items are clicked
+  ui.menuRecently_Opened_Files->setMaxItems(settings.maxRecentFiles());
   connect(ui.menuRecently_Opened_Files, &MruMenu::itemClicked, this, &MainWindow::onFileDropped);
 
   // Create an action group for the annotation tools
@@ -918,6 +919,7 @@ void MainWindow::applySettings() {
   else
     ui.view->setBackgroundBrush(QBrush(settings.bgColor()));
   ui.view->updateOutline();
+  ui.menuRecently_Opened_Files->setMaxItems(settings.maxRecentFiles());
 }
 
 void MainWindow::on_actionPrint_triggered() {

--- a/src/mrumenu.h
+++ b/src/mrumenu.h
@@ -46,6 +46,13 @@ public:
      */
     void addItem(const QString &filename);
 
+    /**
+     * @brief Set maximum number of items
+     *
+     * The last item will be removed if the number is exceeded.
+     */
+    void setMaxItems(int m);
+
 Q_SIGNALS:
 
     /**
@@ -69,6 +76,8 @@ private:
 
     QAction *mSeparator;
     QAction *mClearAction;
+
+    int mMaxItems;
 };
 
 }

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -37,6 +37,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   initIconThemes(settings);
   ui.bgColor->setColor(settings.bgColor());
   ui.fullScreenBgColor->setColor(settings.fullScreenBgColor());
+  ui.maxRecentFiles->setValue(settings.maxRecentFiles());
   ui.slideShowInterval->setValue(settings.slideShowInterval());
   ui.oulineBox->setChecked(settings.isOutlineShown());
   ui.annotationBox->setChecked(settings.isAnnotationsToolbarShown());
@@ -70,6 +71,7 @@ void PreferencesDialog::accept() {
 
   settings.setBgColor(ui.bgColor->color());
   settings.setFullScreenBgColor(ui.fullScreenBgColor->color());
+  settings.setMaxRecentFiles(ui.maxRecentFiles->value());
   settings.setSlideShowInterval(ui.slideShowInterval->value());
   settings.showOutline(ui.oulineBox->isChecked());
   settings.showAnnotationsToolbar(ui.annotationBox->isChecked());

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -66,27 +66,37 @@
         </widget>
        </item>
        <item row="3" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Maximum number of recent files:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QSpinBox" name="maxRecentFiles"/>
+       </item>
+       <item row="4" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Slide show interval (seconds):</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <widget class="QSpinBox" name="slideShowInterval">
          <property name="minimum">
           <number>1</number>
          </property>
         </widget>
        </item>
-       <item row="4" column="0" colspan="2">
+       <item row="5" column="0" colspan="2">
         <widget class="QCheckBox" name="oulineBox">
          <property name="text">
           <string>Show image outline by default</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="0" colspan="2">
+       <item row="6" column="0" colspan="2">
         <widget class="QCheckBox" name="annotationBox">
          <property name="text">
           <string>Show annotations toolbar by default</string>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -32,6 +32,7 @@ Settings::Settings():
   showSidePane_(false),
   slideShowInterval_(5),
   fallbackIconTheme_(QStringLiteral("oxygen")),
+  maxRecentFiles_(5),
   fixedWindowWidth_(640),
   fixedWindowHeight_(480),
   lastWindowWidth_(640),
@@ -52,6 +53,7 @@ bool Settings::load() {
   // showThumbnails_;
   // showSidePane_;
   slideShowInterval_ = settings.value(QStringLiteral("slideShowInterval"), slideShowInterval_).toInt();
+  maxRecentFiles_ = settings.value(QStringLiteral("maxRecentFiles"), maxRecentFiles_).toInt();
   recentlyOpenedFiles_ = settings.value(QStringLiteral("recentlyOpenedFiles")).toStringList();
 
   settings.beginGroup(QStringLiteral("Window"));
@@ -75,6 +77,7 @@ bool Settings::save() {
   settings.setValue(QStringLiteral("bgColor"), bgColor_);
   settings.setValue(QStringLiteral("fullScreenBgColor"), fullScreenBgColor_);
   settings.setValue(QStringLiteral("slideShowInterval"), slideShowInterval_);
+  settings.setValue(QStringLiteral("maxRecentFiles"), maxRecentFiles_);
   settings.setValue(QStringLiteral("recentlyOpenedFiles"), recentlyOpenedFiles_);
 
   settings.beginGroup(QStringLiteral("Window"));

--- a/src/settings.h
+++ b/src/settings.h
@@ -88,6 +88,13 @@ public:
     recentlyOpenedFiles_ = recentlyOpenedFiles;
   }
 
+  int maxRecentFiles() const {
+    return maxRecentFiles_;
+  }
+  void setMaxRecentFiles(int m) {
+    maxRecentFiles_ = m;
+  }
+
   bool rememberWindowSize() const {
     return rememberWindowSize_;
   }
@@ -170,6 +177,7 @@ private:
   int slideShowInterval_;
   QString fallbackIconTheme_;
   QStringList recentlyOpenedFiles_;
+  int maxRecentFiles_;
 
   bool rememberWindowSize_;
   int fixedWindowWidth_;


### PR DESCRIPTION
If it's set to 0, it'll be disabled. It can be from 0 to 99 but the default is 5, as before.

Also closes https://github.com/lxqt/lximage-qt/issues/270