### PR TITLE
Keep zooming state on switching image

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -227,6 +227,7 @@ void ImageView::zoomIn() {
     scaleFactor_ *= 1.1;
     scale(scaleFactor_, scaleFactor_);
     queueGenerateCache();
+    Q_EMIT zooming();
   }
 }
 
@@ -237,6 +238,7 @@ void ImageView::zoomOut() {
     scaleFactor_ /= 1.1;
     scale(scaleFactor_, scaleFactor_);
     queueGenerateCache();
+    Q_EMIT zooming();
   }
 }
 

--- a/src/imageview.h
+++ b/src/imageview.h
@@ -86,6 +86,7 @@ public:
 
 Q_SIGNALS:
   void fileDropped(const QString file);
+  void zooming();
 
 protected:
   virtual void wheelEvent(QWheelEvent* event);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -95,6 +95,8 @@ MainWindow::MainWindow():
 
   connect(ui.view, &ImageView::fileDropped, this, &MainWindow::onFileDropped);
 
+  connect(ui.view, &ImageView::zooming, this, &MainWindow::onZooming);
+
   // install an event filter on the image view
   ui.view->installEventFilter(this);
   ui.view->setBackgroundBrush(QBrush(settings.bgColor()));
@@ -118,6 +120,11 @@ MainWindow::MainWindow():
       ui.actionAnnotations->setChecked(visible);
     }
   });
+
+  auto aGroup = new QActionGroup(this);
+  ui.actionZoomFit->setActionGroup(aGroup);
+  ui.actionOriginalSize->setActionGroup(aGroup);
+  ui.actionZoomFit->setChecked(true);
 
   contextMenu_->addAction(ui.actionPrevious);
   contextMenu_->addAction(ui.actionNext);
@@ -193,23 +200,36 @@ void MainWindow::on_actionAbout_triggered() {
 }
 
 void MainWindow::on_actionOriginalSize_triggered() {
-  ui.view->setAutoZoomFit(false);
-  ui.view->zoomOriginal();
+  if(ui.actionOriginalSize->isChecked()) {
+    ui.view->setAutoZoomFit(false);
+    ui.view->zoomOriginal();
+  }
 }
 
 void MainWindow::on_actionZoomFit_triggered() {
-  ui.view->setAutoZoomFit(true);
-  ui.view->zoomFit();
+  if(ui.actionZoomFit->isChecked()) {
+    ui.view->setAutoZoomFit(true);
+    ui.view->zoomFit();
+  }
 }
 
 void MainWindow::on_actionZoomIn_triggered() {
-  ui.view->setAutoZoomFit(false);
-  ui.view->zoomIn();
+  if(!ui.view->image().isNull()) {
+    ui.view->setAutoZoomFit(false);
+    ui.view->zoomIn();
+  }
 }
 
 void MainWindow::on_actionZoomOut_triggered() {
-  ui.view->setAutoZoomFit(false);
-  ui.view->zoomOut();
+  if(!ui.view->image().isNull()) {
+    ui.view->setAutoZoomFit(false);
+    ui.view->zoomOut();
+  }
+}
+
+void MainWindow::onZooming() {
+  ui.actionZoomFit->setChecked(false);
+  ui.actionOriginalSize->setChecked(false);
 }
 
 void MainWindow::on_actionDrawNone_triggered() {
@@ -296,7 +316,10 @@ void MainWindow::pasteImage(QImage newImage) {
 
   image_ = newImage;
   ui.view->setImage(image_);
-  ui.view->zoomOriginal();
+  // always fit the image on pasting
+  ui.actionZoomFit->setChecked(true);
+  ui.view->setAutoZoomFit(true);
+  ui.view->zoomFit();
 
   updateUI();
 }
@@ -539,7 +562,10 @@ void MainWindow::onImageLoaded() {
 
     loadJob_ = nullptr; // the job object will be freed later automatically
 
-    ui.view->setAutoZoomFit(true);
+    ui.view->setAutoZoomFit(ui.actionZoomFit->isChecked());
+    if(ui.actionOriginalSize->isChecked()) {
+      ui.view->zoomOriginal();
+    }
     ui.view->setImage(image_);
 
    // currentIndex_ should be corrected after loading
@@ -724,7 +750,13 @@ void MainWindow::loadImage(const Fm::FilePath & filePath, QModelIndex index) {
       currentIndex_ = indexFromPath(currentFile_);
     }
     const Fm::CStrPtr file_name = currentFile_.toString();
-    ui.view->setAutoZoomFit(true); // like in onImageLoaded()
+
+    // like in onImageLoaded()
+    ui.view->setAutoZoomFit(ui.actionZoomFit->isChecked());
+    if(ui.actionOriginalSize->isChecked()) {
+      ui.view->zoomOriginal();
+    }
+
     if(mimeType == QLatin1String("image/gif"))
       ui.view->setGifAnimation(QString::fromUtf8(file_name.get()));
     else

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -125,6 +125,8 @@ private Q_SLOTS:
   void on_actionOriginalSize_triggered();
   void on_actionZoomFit_triggered();
 
+  void onZooming();
+
   void on_actionDrawNone_triggered();
   void on_actionDrawArrow_triggered();
   void on_actionDrawRectangle_triggered();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -321,6 +321,9 @@
    </property>
   </action>
   <action name="actionOriginalSize">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="icon">
     <iconset theme="zoom-original">
      <normaloff>.</normaloff>.</iconset>
@@ -333,6 +336,9 @@
    </property>
   </action>
   <action name="actionZoomFit">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="icon">
     <iconset theme="zoom-fit-best">
      <normaloff>.</normaloff>.</iconset>

--- a/src/screenshotdialog.cpp
+++ b/src/screenshotdialog.cpp
@@ -211,6 +211,7 @@ void ScreenshotDialog::doScreenshot() {
 
   Application* app = static_cast<Application*>(qApp);
   MainWindow* window = app->createWindow();
+  window->resize(app->settings().windowWidth(), app->settings().windowHeight());
   if(!image.isNull()) {
     window->pasteImage(image);
   }


### PR DESCRIPTION
Also, resize the screenshot window to the last window size (as is done for new windows).

Closes https://github.com/lxqt/lximage-qt/issues/190