### PR TITLE
Added "Open With.." to File menu

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -32,6 +32,7 @@
 
 #include <libfm-qt/foldermodel.h>
 #include <libfm-qt/proxyfoldermodel.h>
+#include <libfm-qt/filemenu.h>
 #include <gio/gio.h>
 
 #include "modelfilter.h"
@@ -141,6 +142,10 @@ private Q_SLOTS:
 
   void onFileDropped(const QString path);
 
+  void fileMenuAboutToShow();
+  void createOpenWithMenu();
+  void deleteOpenWithMenu();
+
 private:
   void onFolderLoaded();
   void updateUI();
@@ -181,6 +186,8 @@ private:
   // multi-threading loading of images
   LoadImageJob* loadJob_;
   SaveImageJob* saveJob_;
+
+  QPointer<Fm::FileMenu> fileMenu_;
 };
 
 }

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -62,6 +62,11 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <widget class="QMenu" name="openWithMenu">
+     <property name="title">
+      <string>Open &amp;With...</string>
+     </property>
+    </widget>
     <widget class="LxImage::MruMenu" name="menuRecently_Opened_Files">
      <property name="title">
       <string>&amp;Recently Opened Files</string>
@@ -70,6 +75,9 @@
     <addaction name="actionNewWindow"/>
     <addaction name="actionOpenFile"/>
     <addaction name="actionOpenDirectory"/>
+    <addaction name="separator"/>
+    <addaction name="openWithMenu"/>
+    <addaction name="separator"/>
     <addaction name="menuRecently_Opened_Files"/>
     <addaction name="actionReload"/>
     <addaction name="actionScreenshot"/>


### PR DESCRIPTION
It will be enabled only if a file is opened in lximage-qt.

NOTE: The code could be enhanced so that pasted images or unsaved screenshots would also be opened in other apps. That would require saving them in `/tmp` but I don't think it's a good idea because the temporary file would remain there after being opened by another app. That's the case with apps like Screengrab too (when Screengrab exits *after* its unsaved screenshot is opened by another app).

Closes https://github.com/lxqt/lximage-qt/issues/289