### PR TITLE
Added shortcut editor to Preferences

### DIFF
--- a/src/application.h
+++ b/src/application.h
@@ -33,6 +33,12 @@ class Application : public QApplication {
   Q_OBJECT
 
 public:
+  // an Action-Shortcut pair that can be displayed in Preferences
+  struct ShortcutDescription {
+    QString displayText;
+    QKeySequence shortcut;
+  };
+
   Application(int& argc, char** argv);
   bool init(int argc, char** argv);
   bool parseCommandLineArgs();
@@ -56,6 +62,10 @@ public:
 
   void applySettings();
 
+  QHash<QString, ShortcutDescription> defaultShortcuts() const {
+    return defaultShortcuts_;
+  }
+
 public Q_SLOTS:
   void editPreferences();
   void screenshot();
@@ -71,6 +81,7 @@ private:
   Settings settings_;
   int windowCount_;
   QPointer<PreferencesDialog> preferencesDialog_;
+  QHash<QString, ShortcutDescription> defaultShortcuts_; // needed for restoring shortcuts
 };
 
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -989,6 +989,21 @@ void MainWindow::applySettings() {
     ui.view->setBackgroundBrush(QBrush(settings.bgColor()));
   ui.view->updateOutline();
   ui.menuRecently_Opened_Files->setMaxItems(settings.maxRecentFiles());
+
+  // also, update shortcuts
+  QHash<QString, QString> ca = settings.customShortcutActions();
+  const auto defaultShortcuts = app->defaultShortcuts();
+  const auto actions = findChildren<QAction*>();
+  for(const auto& action : actions) {
+     const QString objectName = action->objectName();
+     if(ca.contains(objectName)) {
+       // custom shortcuts are saved in the PortableText format
+       action->setShortcut(QKeySequence(ca.value(objectName), QKeySequence::PortableText));
+     }
+     else { // default shortcuts include all actions
+       action->setShortcut(defaultShortcuts.value(objectName).shortcut);
+     }
+  }
 }
 
 void MainWindow::on_actionPrint_triggered() {

--- a/src/preferencesdialog.h
+++ b/src/preferencesdialog.h
@@ -22,11 +22,36 @@
 #define LXIMAGE_PREFERENCESDIALOG_H
 
 #include <QDialog>
+#include <QStyledItemDelegate>
+#include <QKeySequenceEdit>
 #include "ui_preferencesdialog.h"
 
 namespace LxImage {
 
 class Settings;
+
+class KeySequenceEdit : public QKeySequenceEdit {
+  Q_OBJECT
+public:
+  KeySequenceEdit(QWidget* parent = nullptr): QKeySequenceEdit(parent) {}
+
+protected:
+  virtual void keyPressEvent(QKeyEvent* event);
+};
+
+class Delegate : public QStyledItemDelegate
+{
+  Q_OBJECT
+public:
+  Delegate (QObject *parent = nullptr) : QStyledItemDelegate(parent) {}
+
+  virtual QWidget* createEditor(QWidget* parent,
+                                const QStyleOptionViewItem&,
+                                const QModelIndex&) const;
+
+protected:
+  virtual bool eventFilter(QObject* object, QEvent *event);
+};
 
 class PreferencesDialog : public QDialog {
   Q_OBJECT
@@ -37,11 +62,21 @@ public:
   virtual void accept();
   virtual void done(int r);
 
+protected:
+  virtual void showEvent(QShowEvent* event);
+
+private Q_SLOTS:
+  void onShortcutChange(QTableWidgetItem* item);
+  void restoreDefaultShortcuts();
+
 private:
   void initIconThemes(Settings& settings);
+  void initShortcuts();
+  void applyNewShortcuts();
 
 private:
   Ui::PreferencesDialog ui;
+  QHash<QString, QString> modifiedShortcuts_;
 };
 
 }

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>331</width>
-    <height>225</height>
+    <width>400</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -100,6 +100,46 @@
         <widget class="QCheckBox" name="annotationBox">
          <property name="text">
           <string>Show annotations toolbar by default</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Shortcuts</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QTableWidget" name="tableWidget">
+         <property name="editTriggers">
+          <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SingleSelection</enum>
+         </property>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Action</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Shortcut</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item alignment="Qt::AlignRight">
+        <widget class="QPushButton" name="defaultButton">
+         <property name="text">
+          <string>Default</string>
          </property>
         </widget>
        </item>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -21,6 +21,7 @@
 #include "settings.h"
 #include <QSettings>
 #include <QIcon>
+#include <QKeySequence>
 
 using namespace LxImage;
 
@@ -65,6 +66,16 @@ bool Settings::load() {
   rememberWindowSize_ = settings.value(QStringLiteral("RememberWindowSize"), true).toBool();
   showOutline_ = settings.value(QStringLiteral("ShowOutline"), false).toBool();
   showAnnotationsToolbar_ = settings.value(QStringLiteral("ShowAnnotationsToolbar"), false).toBool();
+  prefSize_ = settings.value(QStringLiteral("PrefSize"), QSize(400, 400)).toSize();
+  settings.endGroup();
+
+  // shortcuts
+  settings.beginGroup(QStringLiteral("Shortcuts"));
+  const QStringList actions = settings.childKeys();
+  for(const auto& action : actions) {
+    QString str = settings.value(action).toString();
+    addShortcut(action, str);
+  }
   settings.endGroup();
 
   return true;
@@ -89,6 +100,19 @@ bool Settings::save() {
   settings.setValue(QStringLiteral("RememberWindowSize"), rememberWindowSize_);
   settings.setValue(QStringLiteral("ShowOutline"), showOutline_);
   settings.setValue(QStringLiteral("ShowAnnotationsToolbar"), showAnnotationsToolbar_);
+  settings.setValue(QStringLiteral("PrefSize"), prefSize_);
+  settings.endGroup();
+
+  // shortcuts
+  settings.beginGroup(QStringLiteral("Shortcuts"));
+  for(int i = 0; i < removedActions_.size(); ++i) {
+    settings.remove(removedActions_.at (i));
+  }
+  QHash<QString, QString>::const_iterator it = actions_.constBegin();
+  while(it != actions_.constEnd()) {
+    settings.setValue(it.key(), it.value());
+    ++it;
+  }
   settings.endGroup();
 
   return true;

--- a/src/settings.h
+++ b/src/settings.h
@@ -25,6 +25,7 @@
 #include <QStringList>
 #include <qcache.h>
 #include <QColor>
+#include <QSize>
 
 namespace LxImage {
 
@@ -168,6 +169,24 @@ public:
     showAnnotationsToolbar_ = show;
   }
 
+  QSize getPrefSize() const {
+    return prefSize_;
+  }
+  void setPrefSize(const QSize &s) {
+    prefSize_ = s;
+  }
+
+  QHash<QString, QString> customShortcutActions() const {
+    return actions_;
+  }
+  void addShortcut(const QString &action, const QString &shortcut) {
+    actions_.insert (action, shortcut);
+  }
+  void removeShortcut(const QString &action) {
+    actions_.remove(action);
+    removedActions_ << action;
+  }
+
 private:
   bool useFallbackIconTheme_;
   QColor bgColor_;
@@ -187,6 +206,11 @@ private:
   bool lastWindowMaximized_;
   bool showOutline_;
   bool showAnnotationsToolbar_;
+
+  QSize prefSize_;
+
+  QHash<QString, QString> actions_;
+  QStringList removedActions_;
 };
 
 }


### PR DESCRIPTION
All actions can have custom shortcuts, those without shortcuts included. Shortcuts can also be removed by entering a modifier key.

Also, Preferences dialog's size is remembered.

NOTE: Qt ≥ 5.13 has a bug about the Meta key. A partial workaround is included, so that Meta can be used in key combinations. It is partial because Meta is temporarily shown as a group of meaningless characters but they disappear afterward. See https://bugreports.qt.io/browse/QTBUG-62102

Closes https://github.com/lxqt/lximage-qt/issues/293