### PR TITLE
screenshotdialog: use shorter suffix in the delay spinbox

### DIFF
--- a/src/screenshotdialog.ui
+++ b/src/screenshotdialog.ui
@@ -71,7 +71,7 @@
    <item row="5" column="1">
     <widget class="QSpinBox" name="delay">
      <property name="suffix">
-      <string> seconds</string>
+      <string> sec</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Use "sec" suffix instead of "seconds" for the delay spinbox, because
the second one doesn't play well with value==1 and looks even worse in
translations.