### PR TITLE
Enhance `-dirscreenshot` cmdline arg description.

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -102,7 +102,7 @@ bool Application::parseCommandLineArgs() {
 
   QCommandLineOption screenshotOptionDir(
     QStringList() << QStringLiteral("d") << QStringLiteral("dirscreenshot"),
-    tr("Take a screenshot to folder without gui"), QString::fromUtf8("folder_to_save_files")
+    tr("Take a screenshot and save it to the directory without showing the GUI"), tr("DIR")
   );
   if(isX11) {
     parser.addOption(screenshotOptionDir);


### PR DESCRIPTION
Slightly enhance `-dirscreenshot` cmdline arg description and its translatability.

Before the patch the `--help` message looked pretty strange because of too long optional arg name:

```
  ...
  -s, --screenshot                            Take a screenshot
  -d, --dirscreenshot <folder_to_save_files>  Take a screenshot to folder
                                              without gui
```

Now it looks slightly better:
```
  ...
  -s, --screenshot           Take a screenshot
  -d, --dirscreenshot <DIR>  Take a screenshot and save it to the directory
                             without showing the GUI
```

The patch enable localization of the `DIR` argument itself as well.

Also as was pointed on the weblate's [comment][1], the help message was a bit obscure.

<hr>

PS: shouldn't this functionality be moved to the `screengrab`?

 [1]: https://weblate.lxqt.org/translate/lxqt/lximage-qt/ru/?checksum=a858451e9102565a