### PR TITLE
Fixed maximization at startup with SVG and GIF images

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -164,6 +164,8 @@ private:
   // FmFileInfo* currentFileInfo_; // info of the current file, can be NULL
   bool imageModified_; // the current image is modified by rotation, flip, or others and needs to be saved
 
+  bool startMaximized_;
+
   // folder browsing
   std::shared_ptr<Fm::Folder> folder_;
   Fm::FilePath folderPath_;


### PR DESCRIPTION
The root of this minor problem was deeper than meets the eye: with SVG and GIF, the maximization info was lost when we resized the window before showing it. This may be a bug in Qt. The patch remembers the maximization info and applies it when the window is going to be shown.

Fixes https://github.com/lxqt/lximage-qt/issues/301