### PR TITLE
Added image size and path to statusbar

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(lximage-qt_SRCS
     settings.cpp
     graphicsscene.cpp
     mrumenu.cpp
+    statusbar.cpp
 
     upload/imageshackprovider.cpp
     upload/imageshackupload.cpp

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -681,17 +681,22 @@ void MainWindow::updateUI() {
     if(loadJob_) { // if loading is in progress
       title = tr("[*]%1 (Loading...) - Image Viewer")
                 .arg(QString::fromUtf8(dispName.get()));
+      ui.statusBar->setText();
     }
     else {
       if(image_.isNull()) {
         title = tr("[*]%1 (Failed to Load) - Image Viewer")
                   .arg(QString::fromUtf8(dispName.get()));
+        ui.statusBar->setText();
       }
       else {
+        const QString filePath = QString::fromUtf8(dispName.get());
         title = tr("[*]%1 (%2x%3) - Image Viewer")
-                  .arg(QString::fromUtf8(dispName.get()))
+                  .arg(filePath)
                   .arg(image_.width())
                   .arg(image_.height());
+        ui.statusBar->setText(QStringLiteral("%1×%2").arg(image_.width()).arg(image_.height()),
+                              filePath);
         if (!isVisible()) {
           /* Here we try to implement the following behavior as far as possible:
               (1) A minimum size of 400x400 is assumed;
@@ -730,6 +735,7 @@ void MainWindow::updateUI() {
   }
   else {
     title = tr("[*]Image Viewer");
+    ui.statusBar->setText();
   }
   setWindowTitle(title);
   setWindowModified(imageModified_);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -179,7 +179,7 @@
    <addaction name="separator"/>
    <addaction name="actionSlideShow"/>
   </widget>
-  <widget class="QStatusBar" name="statusBar"/>
+  <widget class="LxImage::StatusBar" name="statusBar"/>
   <widget class="QToolBar" name="annotationsToolBar">
    <property name="windowTitle">
     <string>Annotations Toolbar</string>
@@ -656,6 +656,12 @@
    <class>LxImage::MruMenu</class>
    <extends>QMenu</extends>
    <header>mrumenu.h</header>
+  </customwidget>
+  <customwidget>
+   <class>LxImage::StatusBar</class>
+   <extends>QStatusBar</extends>
+   <header>statusbar.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -1,0 +1,96 @@
+/*
+ * LXImage-Qt - a simple and fast image viewer
+ * Copyright (C) 2013  PCMan <pcman.tw@gmail.com>
+ *
+ * StatusBar by tsujan <tsujan2000@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "statusbar.h"
+#include <QPainter>
+#include <QStyleOption>
+
+#define MESSAGE_DELAY 250
+
+namespace LxImage {
+
+Label::Label(QWidget* parent, Qt::WindowFlags f):
+  QLabel(parent, f),
+  lastWidth_(0) {
+  setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+  // set a min width to prevent the window from widening with long texts
+  setMinimumWidth(fontMetrics().averageCharWidth() * 10);
+}
+
+// A simplified version of QLabel::paintEvent()
+// without pixmap or shortcut but with eliding.
+void Label::paintEvent(QPaintEvent* /*event*/) {
+  QRect cr = contentsRect().adjusted(margin(), margin(), -margin(), -margin());
+  QString txt = text();
+  // if the text is changed or its rect is resized (due to window resizing),
+  // find whether it needs to be elided...
+  if(txt != lastText_ || cr.width() != lastWidth_) {
+    lastText_ = txt;
+    lastWidth_ = cr.width();
+    elidedText_ = fontMetrics().elidedText(txt, Qt::ElideMiddle, cr.width());
+  }
+  // ... then, draw the (elided) text
+  if(!elidedText_.isEmpty()) {
+    QPainter painter(this);
+    QStyleOption opt;
+    opt.initFrom(this);
+    style()->drawItemText(&painter, cr, alignment(), opt.palette, isEnabled(), elidedText_, foregroundRole());
+  }
+}
+
+StatusBar::StatusBar(QWidget* parent)
+  : QStatusBar(parent) {
+  // NOTE: The spacing is set to 6 in Qt → qstatusbar.cpp.
+  sizeLabel0_ = new QLabel(QStringLiteral("<b>") + tr("Size:") + QStringLiteral("</b>"));
+  sizeLabel0_->setContentsMargins(2, 0, 0, 0);
+  sizeLabel0_->hide();
+  addWidget(sizeLabel0_);
+
+  sizeLabel_ = new QLabel();
+  sizeLabel_->hide();
+  sizeLabel_->setContentsMargins(0, 0, 2, 0);
+  addWidget(sizeLabel_);
+
+  pathLabel0_ = new QLabel(QStringLiteral("<b>") + tr("Path:") + QStringLiteral("</b>"));
+  pathLabel0_->hide();
+  addWidget(pathLabel0_);
+
+  pathLabel_ = new Label();
+  pathLabel_->hide();
+  pathLabel_->setFrameShape(QFrame::NoFrame);
+  addWidget(pathLabel_);
+}
+
+StatusBar::~StatusBar() {
+}
+
+void StatusBar::setText(const QString& sizeTxt, const QString& pathTxt) {
+  sizeLabel_->setText(sizeTxt);
+  sizeLabel0_->setVisible(!sizeTxt.isEmpty());
+  sizeLabel_->setVisible(!sizeTxt.isEmpty());
+
+  pathLabel_->setText(pathTxt);
+  pathLabel0_->setVisible(!pathTxt.isEmpty());
+  pathLabel_->setVisible(!pathTxt.isEmpty());
+}
+
+}

--- a/src/statusbar.h
+++ b/src/statusbar.h
@@ -1,0 +1,62 @@
+/*
+ * LXImage-Qt - a simple and fast image viewer
+ * Copyright (C) 2013  PCMan <pcman.tw@gmail.com>
+ *
+ * StatusBar by tsujan <tsujan2000@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LXIMAGE_STATUSBAR_H
+#define LXIMAGE_STATUSBAR_H
+
+#include <QStatusBar>
+#include <QLabel>
+
+namespace LxImage {
+
+class Label : public QLabel {
+  Q_OBJECT
+
+public:
+  explicit Label(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+
+protected:
+  void paintEvent(QPaintEvent* event) override;
+
+private:
+  QString elidedText_;
+  QString lastText_;
+  int lastWidth_;
+};
+
+class StatusBar : public QStatusBar {
+Q_OBJECT
+
+public:
+  explicit StatusBar(QWidget* parent = nullptr);
+  ~StatusBar();
+
+  void setText(const QString& sizeTxt = QString(), const QString& pathTxt = QString());
+
+private:
+  QLabel *sizeLabel0_, *sizeLabel_, *pathLabel0_;
+  Label *pathLabel_; // an elided path
+};
+
+}
+
+#endif // LXIMAGE_STATUSBAR_H


### PR DESCRIPTION
The path text will be elided if needed.

The title-bar info is kept intact.

Closes https://github.com/lxqt/lximage-qt/issues/193