### PR TITLE
fix bug #307 : drawing rectangle doesn't show

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -137,10 +137,14 @@ void ImageView::mouseReleaseEvent(QMouseEvent* event) {
       drawArrow(painter, startPoint, endPoint, M_PI / 8, 25);
       break;
     case ToolRectangle:
+      // Draw the rectangle in the image and scene at the same time
       painter.drawRect(QRect(startPoint, endPoint));
+      scene_->addRect(QRect(startPoint, endPoint), painter.pen());
       break;
     case ToolCircle:
+      // Draw the circle in the image and scene at the same time
       painter.drawEllipse(QRect(startPoint, endPoint));
+      scene_->addEllipse(QRect(startPoint, endPoint), painter.pen());
       break;
     case ToolNumber:
     {
@@ -161,15 +165,21 @@ void ImageView::mouseReleaseEvent(QMouseEvent* event) {
                         textRect.top() + (textRect.height() / 2 - radius),
                         radius * 2, radius * 2);
 
-      // Draw the path
+      // Draw the path in the image
       QPainterPath path;
       path.addEllipse(circleRect);
       painter.fillPath(path, Qt::red);
       painter.drawPath(path);
+      // Draw the path in the sence
+      scene_->addPath(path, painter.pen(), QBrush(Qt::red));
 
-      // Draw the text
+      // Draw the text in the image
       painter.setPen(Qt::white);
       painter.drawText(textRect, Qt::AlignCenter, text);
+      // Draw the text in the sence
+      QGraphicsTextItem *textItem = scene_->addText(text, painter.font());
+      textItem->setPos(textRect.x() - textRect.width() / 8 , textRect.y() - textRect.height() / 8);
+      textItem->setDefaultTextColor(Qt::white);
 
       break;
     }
@@ -573,8 +583,10 @@ void ImageView::drawArrow(QPainter &painter,
                           qreal tipAngle,
                           int tipLen) const
 {
-  // Draw the line
+  // Draw the line in the inmage
   painter.drawLine(start, end);
+  // Draw the line in the scene
+  scene_->addLine(QLine(start, end), painter.pen());
 
   // Calculate the angle of the line
   QPoint delta = end - start;
@@ -590,9 +602,12 @@ void ImageView::drawArrow(QPainter &painter,
     static_cast<int>(qCos(angle - tipAngle) * tipLen)
   );
 
-  // Draw the two lines
+  // Draw the two lines in the image
   painter.drawLine(end, end + tip1);
   painter.drawLine(end, end + tip2);
+  // Draw the two lines in the scene
+  scene_->addLine(QLine(end, end+tip1), painter.pen());
+  scene_->addLine(QLine(end, end+tip2), painter.pen());
 }
 
 } // namespace LxImage

--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -275,6 +275,9 @@ void ImageView::drawOutline() {
 void ImageView::setImage(const QImage& image, bool show) {
   if(show && (gifMovie_ || isSVG)) { // a gif animation or SVG file was shown before
     scene_->clear();
+    // all annotations have been removed and delete by scene_->clear()
+    // so we clear annotations list
+    annotations.clear();
     isSVG = false;
     if(gifMovie_) { // should be deleted explicitly
       delete gifMovie_;
@@ -290,6 +293,18 @@ void ImageView::setImage(const QImage& image, bool show) {
     outlineItem_->hide();
     outlineItem_->setPen(QPen(Qt::NoPen));
     scene_->addItem(outlineItem_);
+  }
+  else {
+    if (!annotations.isEmpty()){
+      // remove all annotations in the scene one by one
+      for (const auto &annotation : annotations){
+        scene_->removeItem(annotation);
+      }
+      // scene_->removeItem() just remove the items from the scene
+      // here we delete all items to prevent a memory leak
+      qDeleteAll(annotations.begin(), annotations.end());
+      annotations.clear();
+    }
   }
 
   image_ = image;
@@ -318,11 +333,8 @@ void ImageView::setImage(const QImage& image, bool show) {
     zoomFit();
   queueGenerateCache();
 
-  // clear the numbering and annotation items in the scene
+  // clear the numbering
   nextNumber = 1;
-  for (QGraphicsItem *annotation : annotations){
-      scene_->removeItem(annotation);
-  }
 }
 
 void ImageView::setGifAnimation(const QString& fileName) {

--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -177,9 +177,11 @@ void ImageView::mouseReleaseEvent(QMouseEvent* event) {
       painter.setPen(Qt::white);
       painter.drawText(textRect, Qt::AlignCenter, text);
       // Draw the text in the sence
-      QGraphicsTextItem *textItem = scene_->addText(text, painter.font());
-      textItem->setPos(textRect.x() - textRect.width() / 8 , textRect.y() - textRect.height() / 8);
-      textItem->setDefaultTextColor(Qt::white);
+      QGraphicsSimpleTextItem *textItem = new QGraphicsSimpleTextItem(text);
+      textItem->setFont(font);
+      textItem->setBrush(Qt::white);
+      textItem->setPos(textRect.topLeft());
+      scene_->addItem(textItem);
       annotations.append(textItem);
 
       break;

--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -134,7 +134,7 @@ void ImageView::mouseReleaseEvent(QMouseEvent* event) {
 
     switch (currentTool) {
     case ToolArrow:
-      drawArrow(painter, startPoint, endPoint, M_PI / 8, 25, &annotations);
+      drawArrow(painter, startPoint, endPoint, M_PI / 8, 25);
       break;
     case ToolRectangle:
       // Draw the rectangle in the image and scene at the same time
@@ -599,13 +599,12 @@ void ImageView::drawArrow(QPainter &painter,
                           const QPoint &start,
                           const QPoint &end,
                           qreal tipAngle,
-                          int tipLen,
-                          QList<QGraphicsItem *> *annotations) const
+                          int tipLen)
 {
   // Draw the line in the inmage
   painter.drawLine(start, end);
   // Draw the line in the scene
-  annotations->append(scene_->addLine(QLine(start, end), painter.pen()));
+  annotations.append(scene_->addLine(QLine(start, end), painter.pen()));
 
   // Calculate the angle of the line
   QPoint delta = end - start;
@@ -625,8 +624,8 @@ void ImageView::drawArrow(QPainter &painter,
   painter.drawLine(end, end + tip1);
   painter.drawLine(end, end + tip2);
   // Draw the two lines in the scene
-  annotations->append(scene_->addLine(QLine(end, end+tip1), painter.pen()));
-  annotations->append(scene_->addLine(QLine(end, end+tip2), painter.pen()));
+  annotations.append(scene_->addLine(QLine(end, end+tip1), painter.pen()));
+  annotations.append(scene_->addLine(QLine(end, end+tip2), painter.pen()));
 }
 
 } // namespace LxImage

--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -134,17 +134,17 @@ void ImageView::mouseReleaseEvent(QMouseEvent* event) {
 
     switch (currentTool) {
     case ToolArrow:
-      drawArrow(painter, startPoint, endPoint, M_PI / 8, 25);
+      drawArrow(painter, startPoint, endPoint, M_PI / 8, 25, &annotations);
       break;
     case ToolRectangle:
       // Draw the rectangle in the image and scene at the same time
       painter.drawRect(QRect(startPoint, endPoint));
-      scene_->addRect(QRect(startPoint, endPoint), painter.pen());
+      annotations.append(scene_->addRect(QRect(startPoint, endPoint), painter.pen()));
       break;
     case ToolCircle:
       // Draw the circle in the image and scene at the same time
       painter.drawEllipse(QRect(startPoint, endPoint));
-      scene_->addEllipse(QRect(startPoint, endPoint), painter.pen());
+      annotations.append(scene_->addEllipse(QRect(startPoint, endPoint), painter.pen()));
       break;
     case ToolNumber:
     {
@@ -171,7 +171,7 @@ void ImageView::mouseReleaseEvent(QMouseEvent* event) {
       painter.fillPath(path, Qt::red);
       painter.drawPath(path);
       // Draw the path in the sence
-      scene_->addPath(path, painter.pen(), QBrush(Qt::red));
+      annotations.append(scene_->addPath(path, painter.pen(), QBrush(Qt::red)));
 
       // Draw the text in the image
       painter.setPen(Qt::white);
@@ -180,6 +180,7 @@ void ImageView::mouseReleaseEvent(QMouseEvent* event) {
       QGraphicsTextItem *textItem = scene_->addText(text, painter.font());
       textItem->setPos(textRect.x() - textRect.width() / 8 , textRect.y() - textRect.height() / 8);
       textItem->setDefaultTextColor(Qt::white);
+      annotations.append(textItem);
 
       break;
     }
@@ -317,8 +318,11 @@ void ImageView::setImage(const QImage& image, bool show) {
     zoomFit();
   queueGenerateCache();
 
-  // clear the numbering
+  // clear the numbering and annotation items in the scene
   nextNumber = 1;
+  for (QGraphicsItem *annotation : annotations){
+      scene_->removeItem(annotation);
+  }
 }
 
 void ImageView::setGifAnimation(const QString& fileName) {
@@ -581,12 +585,13 @@ void ImageView::drawArrow(QPainter &painter,
                           const QPoint &start,
                           const QPoint &end,
                           qreal tipAngle,
-                          int tipLen) const
+                          int tipLen,
+                          QList<QGraphicsItem *> *annotations) const
 {
   // Draw the line in the inmage
   painter.drawLine(start, end);
   // Draw the line in the scene
-  scene_->addLine(QLine(start, end), painter.pen());
+  annotations->append(scene_->addLine(QLine(start, end), painter.pen()));
 
   // Calculate the angle of the line
   QPoint delta = end - start;
@@ -606,8 +611,8 @@ void ImageView::drawArrow(QPainter &painter,
   painter.drawLine(end, end + tip1);
   painter.drawLine(end, end + tip2);
   // Draw the two lines in the scene
-  scene_->addLine(QLine(end, end+tip1), painter.pen());
-  scene_->addLine(QLine(end, end+tip2), painter.pen());
+  annotations->append(scene_->addLine(QLine(end, end+tip1), painter.pen()));
+  annotations->append(scene_->addLine(QLine(end, end+tip2), painter.pen()));
 }
 
 } // namespace LxImage

--- a/src/imageview.h
+++ b/src/imageview.h
@@ -109,7 +109,8 @@ private:
                  const QPoint &start,
                  const QPoint &end,
                  qreal tipAngle,
-                 int tipLen) const;
+                 int tipLen,
+                 QList<QGraphicsItem *> *annotations) const;
 
 private Q_SLOTS:
   void onFileDropped(const QString file);
@@ -132,6 +133,7 @@ private:
   bool isSVG; // is the image an SVG file?
   Tool currentTool; // currently selected tool
   QPoint startPoint; // starting point for the tool
+  QList<QGraphicsItem *> annotations;	//annotation items which have been drawn in the scene
   int nextNumber;
   bool showOutline_;
 };

--- a/src/imageview.h
+++ b/src/imageview.h
@@ -109,8 +109,7 @@ private:
                  const QPoint &start,
                  const QPoint &end,
                  qreal tipAngle,
-                 int tipLen,
-                 QList<QGraphicsItem *> *annotations) const;
+                 int tipLen);
 
 private Q_SLOTS:
   void onFileDropped(const QString file);


### PR DESCRIPTION
The reason for this bug is that when paintdevice is a widget,
QPainter can only be used inside a paintEvent() function or in a
function called by paintEvent()

this commit fix this bug by drawing the same rectangle in the scene

LXImage use QGraphicsView to display image and QGraphicsView is a
part of the Grapics View Framework. Usually by calling update(), a
widget is able to trigger paintEvent(). However, as far as i know,
in the Graphics View Framework, it's impossible for QGraphicsView
to tigger the paintEvent() by calling update()

so i choose the Graphics View Framwork way to draw the rectangle
something like: scene.addRect(...) 