### PR TITLE
Fixed memory leaks in annotations

### DIFF
--- a/src/imageview.h
+++ b/src/imageview.h
@@ -111,6 +111,8 @@ private:
                  qreal tipAngle,
                  int tipLen);
 
+  void removeAnnotations();
+
 private Q_SLOTS:
   void onFileDropped(const QString file);
   void generateCache();


### PR DESCRIPTION
There were memory leaks with SVG and GIF.

NOTE: The annotations code structure is suboptimal for various reasons and might need a refactoring later.