### PR TITLE
Show error message if saving with a format is not supported

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -819,10 +819,15 @@ void MainWindow::saveImage(const Fm::FilePath & filePath) {
   saveJob_ = new SaveImageJob(ui.view->image(), filePath);
   connect(saveJob_, &Fm::Job::finished, this, &MainWindow::onImageSaved);
   connect(saveJob_, &Fm::Job::error, this
-        , [] (const Fm::GErrorPtr & err, Fm::Job::ErrorSeverity /*severity*/, Fm::Job::ErrorAction & /*response*/)
+        , [this] (const Fm::GErrorPtr & err, Fm::Job::ErrorSeverity severity, Fm::Job::ErrorAction & /*response*/)
         {
           // TODO: show a info bar?
-          qWarning().noquote() << "lximage-qt:" << err.message();
+          if(severity > Fm::Job::ErrorSeverity::MODERATE) {
+            QMessageBox::critical(this, QObject::tr("Error"), err.message());
+          }
+          else {
+            qWarning().noquote() << "lximage-qt:" << err.message();
+          }
         }
       , Qt::BlockingQueuedConnection);
   saveJob_->runAsync();
@@ -831,9 +836,7 @@ void MainWindow::saveImage(const Fm::FilePath & filePath) {
 
 QGraphicsItem* MainWindow::getImageGraphicsItem() {
   if(!ui.view->items().isEmpty()) {
-    return (ui.view->items().size() > 1
-            ? ui.view->items().at(1) // the first item is outline (the uppermost item)
-            : ui.view->items().at(0));
+    return (ui.view->items().last()); // the lowermost item
   }
   return nullptr;
 }

--- a/src/saveimagejob.cpp
+++ b/src/saveimagejob.cpp
@@ -45,7 +45,17 @@ void SaveImageJob::exec() {
     ++format;
 
   QBuffer imageBuffer;
-  image_.save(&imageBuffer, format); // save the image to buffer
+  // save the image to buffer
+  if(!image_.save(&imageBuffer, format)) {
+    // do not create an empty file when the format is not supported
+    Fm::GErrorPtr err = Fm::GErrorPtr {
+                            G_IO_ERROR,
+                            G_IO_ERROR_NOT_SUPPORTED,
+                            tr("Cannot save with this image format!")
+    };
+    emitError(err, Fm::Job::ErrorSeverity::SEVERE);
+    return;
+  }
 
   GFileOutputStream* fileStream = nullptr;
   Fm::GErrorPtr error;


### PR DESCRIPTION
For example, images cannot be saved as SVG or GIF and it's better to inform the user about that, instead of creating an empty file or, worse, overwriting an existing image.

Also, corrected `MainWindow::getImageGraphicsItem()` because it didn't take a recent annotations commit into account (annotations are now added as items).