### PR TITLE
Prevent users from defining ambiguous shortcuts

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -164,6 +164,9 @@ MainWindow* Application::createWindow() {
   if(defaultShortcuts_.isEmpty()) {
     const auto actions = window->findChildren<QAction*>();
     for(const auto& action : actions) {
+      if(action->objectName().isEmpty() || action->text().isEmpty()) {
+        continue;
+      }
       QKeySequence seq = action->shortcut();
       ShortcutDescription s;
       s.displayText = action->text().remove QStringLiteral("&"); // without mnemonics

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -336,6 +336,9 @@ void PreferencesDialog::restoreDefaultShortcuts() {
     // do nothing if there's no custom shortcut
     return;
   }
+
+  showWarning(QString());
+
   disconnect(ui.tableWidget, &QTableWidget::itemChanged, this, &PreferencesDialog::onShortcutChange);
   int cur = ui.tableWidget->currentColumn() == 0 ? 0 : ui.tableWidget->currentRow();
   ui.tableWidget->setSortingEnabled(false);

--- a/src/preferencesdialog.h
+++ b/src/preferencesdialog.h
@@ -24,6 +24,7 @@
 #include <QDialog>
 #include <QStyledItemDelegate>
 #include <QKeySequenceEdit>
+#include <QTimer>
 #include "ui_preferencesdialog.h"
 
 namespace LxImage {
@@ -73,10 +74,14 @@ private:
   void initIconThemes(Settings& settings);
   void initShortcuts();
   void applyNewShortcuts();
+  void showWarning(const QString& text, bool temporary = true);
 
 private:
   Ui::PreferencesDialog ui;
   QHash<QString, QString> modifiedShortcuts_;
+  QHash<QString, QString> allShortcuts_; // only used for checking ambiguity
+  QString permanentWarning_;
+  QTimer *warningTimer_;
 };
 
 }

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -148,6 +148,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="warningLabel">
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::NoTextInteraction</set>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -106,7 +106,7 @@ bool Settings::save() {
   // shortcuts
   settings.beginGroup(QStringLiteral("Shortcuts"));
   for(int i = 0; i < removedActions_.size(); ++i) {
-    settings.remove(removedActions_.at (i));
+    settings.remove(removedActions_.at(i));
   }
   QHash<QString, QString>::const_iterator it = actions_.constBegin();
   while(it != actions_.constEnd()) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -180,7 +180,7 @@ public:
     return actions_;
   }
   void addShortcut(const QString &action, const QString &shortcut) {
-    actions_.insert (action, shortcut);
+    actions_.insert(action, shortcut);
   }
   void removeShortcut(const QString &action) {
     actions_.remove(action);


### PR DESCRIPTION
If the user tries to define an ambiguous shortcut, the shortcut will not change but a temporary warning bar will appear at the bottom of Preferences dialog for 2.5 seconds.

In addition, if an ambiguous shortcut was defined by editing the config file (while lximage-qt was closed) or by an older version of lximage-qt, a permanent warning bar will appear. It will be removed once the ambiguity is resolved.

Also:

 * Added a tooltip about shortcut removal; and
 * Fixed a bug in defining a shortcut for the annotation toolbar.

NOTE: I'll update the translations after this is merged.

Closes https://github.com/lxqt/lximage-qt/issues/330