### PR TITLE
Add depreciation notice to screenshot command line options, closes #334

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -93,7 +93,7 @@ bool Application::parseCommandLineArgs() {
 
   QCommandLineOption screenshotOption(
     QStringList() << QStringLiteral("s") << QStringLiteral("screenshot"),
-    tr("Take a screenshot")
+    tr("Take a screenshot (deprecated, please use screengrab instead)")
   );
   if(isX11) {
     parser.addOption(screenshotOption);
@@ -102,7 +102,7 @@ bool Application::parseCommandLineArgs() {
 
   QCommandLineOption screenshotOptionDir(
     QStringList() << QStringLiteral("d") << QStringLiteral("dirscreenshot"),
-    tr("Take a screenshot and save it to the directory without showing the GUI"), tr("DIR")
+    tr("Take a screenshot and save it to the directory without showing the GUI (deprecated, please use screengrab instead)"), tr("DIR")
   );
   if(isX11) {
     parser.addOption(screenshotOptionDir);


### PR DESCRIPTION
LXQt's screenshot utility is screengrab and the current X11 screenshot code may be removed from lximage-qt sooner or later