### PR TITLE
Consult Qt for supported mimetypes

### DIFF
--- a/src/modelfilter.cpp
+++ b/src/modelfilter.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "modelfilter.h"
+#include <QImageReader>
 
 using namespace LxImage;
 
@@ -34,7 +35,9 @@ bool ModelFilter::filterAcceptsRow(const Fm::ProxyFolderModel* model, const std:
 {
   Q_UNUSED(model)
 
-  // filter out non-image files and formats that we don't support.
-  return info && info->isImage();
+  // Filter out formats that we don't support but don't use FileInfo::isImage() because
+  // it only checks if the mimetype starts with "image/" while Qt may support more.
+  static const QList<QByteArray> mimeTypes = QImageReader::supportedMimeTypes();
+  return info && mimeTypes.contains(info->mimeType()->name());
 }
 


### PR DESCRIPTION
Previously, the code used `Fm::FileInfo::isImage()`, which only checks if the mimetype starts with "image/", while Qt may support more.

Closes https://github.com/lxqt/lximage-qt/issues/336