### PR TITLE
Populate MimeType property of lximage-qt.desktop automatically

### DIFF
--- a/data/lximage-qt.desktop.in
+++ b/data/lximage-qt.desktop.in
@@ -5,4 +5,3 @@ Exec=lximage-qt %F
 StartupNotify=true
 Terminal=false
 Categories=Graphics;Viewer;RasterGraphics;2DGraphics;Photography;
-MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/png;image/tiff;image/x-bmp;image/x-pcx;image/x-tga;image/x-portable-pixmap;image/x-portable-bitmap;image/x-targa;image/x-portable-greymap;application/pcx;image/svg+xml;image/svg-xml;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,6 @@ include(LXQtTranslateDesktop)
 
 file(GLOB desktop_files_in ../data/*.desktop.in)
 lxqt_translate_desktop(desktop_files SOURCES ${desktop_files_in} USE_YAML)
-install(FILES ${desktop_files} DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
 
 add_executable(lximage-qt
     ${lximage-qt_SRCS}
@@ -102,4 +101,12 @@ target_link_libraries(lximage-qt
     ${XFIXES_LDFLAGS}
 )
 
+add_custom_command(OUTPUT lximage-qt.desktop
+    APPEND
+    COMMAND echo -n "MimeType=" >> ${CMAKE_CURRENT_BINARY_DIR}/lximage-qt.desktop
+    COMMAND $<TARGET_FILE:lximage-qt> --supportedmimetypes >> ${CMAKE_CURRENT_BINARY_DIR}/lximage-qt.desktop
+    DEPENDS lximage-qt
+)
+
 install(TARGETS lximage-qt RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+install(FILES ${desktop_files} DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -24,11 +24,13 @@
 #include <QDBusInterface>
 #include <QPixmapCache>
 #include <QX11Info>
+#include <iostream>
 #include "applicationadaptor.h"
 #include "screenshotdialog.h"
 #include "mainwindow.h"
 
 using namespace LxImage;
+using namespace std;
 
 static const char* serviceName = "org.lxde.LxImage";
 static const char* ifaceName = "org.lxde.LxImage.Application";
@@ -108,6 +110,12 @@ bool Application::parseCommandLineArgs() {
     parser.addOption(screenshotOptionDir);
   }
 
+  QCommandLineOption supportedMimeTypes(
+    QStringLiteral("supportedmimetypes"),
+    tr("Print an ASCII-encoded, semicolon-separated list of supported image types")
+  );
+  parser.addOption(supportedMimeTypes);
+
   const QString files = tr("[FILE1, FILE2,...]");
   parser.addPositionalArgument(QStringLiteral("files"), files, files);
 
@@ -124,6 +132,17 @@ bool Application::parseCommandLineArgs() {
     paths.push_back(info.absoluteFilePath());
   }
 
+
+  //print supported image types
+  if (parser.isSet(supportedMimeTypes)) {
+    for(const QByteArray& type : QImageReader::supportedMimeTypes()) {
+      //only include image types and not application/pdf
+      if(type.startsWith("image/"))
+        cout << type.constData() << ';';
+    }
+    cout << endl;
+    return false;
+  }
 
   //silent no-gui screenshot
   if(isX11) {


### PR DESCRIPTION
This ensures that support for image/webp is advertised when available.