### PR TITLE
Added options for thumbnails

### DIFF
--- a/src/loadimagejob.cpp
+++ b/src/loadimagejob.cpp
@@ -109,7 +109,7 @@ void LoadImageJob::exec() {
             ExifByteOrder bo = exif_data_get_byte_order(exif_data.get());
             /* bo == EXIF_BYTE_ORDER_INTEL ; */
             orient = exif_get_short (orient_ent->data, bo);
-            QMatrix m;
+            QTransform m;
             switch(orient) {
               case 1: /* no rotation */
                 break;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -104,13 +104,16 @@ MainWindow::MainWindow():
 
   // install an event filter on the image view
   ui.view->installEventFilter(this);
+
   ui.view->setBackgroundBrush(QBrush(settings.bgColor()));
+
   ui.view->updateOutline();
+
   ui.view->showOutline(settings.isOutlineShown());
   ui.actionShowOutline->setChecked(settings.isOutlineShown());
 
-  if(settings.showThumbnails())
-    setShowThumbnails(true);
+  setShowThumbnails(settings.showThumbnails());
+  ui.actionShowThumbnails->setChecked(settings.showThumbnails());
 
   ui.annotationsToolBar->setVisible(settings.isAnnotationsToolbarShown());
   ui.actionAnnotations->setChecked(settings.isAnnotationsToolbarShown());
@@ -580,7 +583,7 @@ void MainWindow::onImageLoaded() {
     if(ui.actionOriginalSize->isChecked()) {
       ui.view->zoomOriginal();
     }
-    
+
     ui.view->setImage(image_);
 
     // currentIndex_ should be corrected after loading

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -85,7 +85,11 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   ui.oulineBox->setChecked(settings.isOutlineShown());
   ui.annotationBox->setChecked(settings.isAnnotationsToolbarShown());
   ui.forceZoomFitBox->setChecked(settings.forceZoomFit());
-  
+
+  ui.thumbnailBox->setChecked(settings.showThumbnails());
+  // the max. thumbnail size spinbox is in MiB
+  ui.thumbnailSpin->setValue(qBound(0, settings.maxThumbnailFileSize() / 1024, 1024));
+
   // shortcuts
   initShortcuts();
 }
@@ -140,6 +144,10 @@ void PreferencesDialog::accept() {
   settings.showOutline(ui.oulineBox->isChecked());
   settings.showAnnotationsToolbar(ui.annotationBox->isChecked());
   settings.setForceZoomFit(ui.forceZoomFitBox->isChecked());
+
+  settings.setShowThumbnails(ui.thumbnailBox->isChecked());
+  // the max. thumbnail size spinbox is in MiB
+  settings.setMaxThumbnailFileSize(ui.thumbnailSpin->value() * 1024);
 
   applyNewShortcuts();
   settings.save();

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -106,7 +106,44 @@
        <item row="7" column="0" colspan="2">
         <widget class="QCheckBox" name="forceZoomFitBox">
          <property name="text">
-          <string>Force zoom to fit when loading images</string>
+          <string>Fit images when navigating</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_3">
+      <attribute name="title">
+       <string>Thumbnails</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout_2">
+       <item row="1" column="0">
+        <widget class="QLabel" name="thumbnailLabel">
+         <property name="text">
+          <string>Image size limit for built-in thumbnailer:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QSpinBox" name="thumbnailSpin">
+         <property name="suffix">
+          <string> MiB</string>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>1024</number>
+         </property>
+         <property name="value">
+          <number>4</number>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QCheckBox" name="thumbnailBox">
+         <property name="text">
+          <string>Show thumbnails dock by default</string>
          </property>
         </widget>
        </item>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -52,7 +52,6 @@ bool Settings::load() {
   fallbackIconTheme_ = settings.value(QStringLiteral("fallbackIconTheme"), fallbackIconTheme_).toString();
   bgColor_ = settings.value(QStringLiteral("bgColor"), bgColor_).value<QColor>();
   fullScreenBgColor_ = settings.value(QStringLiteral("fullScreenBgColor"), fullScreenBgColor_).value<QColor>();
-  // showThumbnails_;
   // showSidePane_;
   slideShowInterval_ = settings.value(QStringLiteral("slideShowInterval"), slideShowInterval_).toInt();
   maxRecentFiles_ = settings.value(QStringLiteral("maxRecentFiles"), maxRecentFiles_).toInt();
@@ -78,6 +77,11 @@ bool Settings::load() {
     QString str = settings.value(action).toString();
     addShortcut(action, str);
   }
+  settings.endGroup();
+
+  settings.beginGroup(QStringLiteral("Thumbnail"));
+  showThumbnails_ = settings.value(QStringLiteral("ShowThumbnails"), false).toBool();
+  setMaxThumbnailFileSize(qMax(settings.value(QStringLiteral("MaxThumbnailFileSize"), 4096).toInt(), 1024));
   settings.endGroup();
 
   return true;
@@ -116,6 +120,11 @@ bool Settings::save() {
     settings.setValue(it.key(), it.value());
     ++it;
   }
+  settings.endGroup();
+
+  settings.beginGroup(QStringLiteral("Thumbnail"));
+  settings.setValue(QStringLiteral("ShowThumbnails"), showThumbnails_);
+  settings.setValue(QStringLiteral("MaxThumbnailFileSize"), maxThumbnailFileSize());
   settings.endGroup();
 
   return true;

--- a/src/settings.h
+++ b/src/settings.h
@@ -26,6 +26,7 @@
 #include <qcache.h>
 #include <QColor>
 #include <QSize>
+#include <libfm-qt/core/thumbnailjob.h>
 
 namespace LxImage {
 
@@ -68,6 +69,14 @@ public:
   }
   void setShowThumbnails(bool show) {
     showThumbnails_ = show;
+  }
+
+  int maxThumbnailFileSize() const {
+    return Fm::ThumbnailJob::maxThumbnailFileSize();
+  }
+
+  void setMaxThumbnailFileSize(int size) {
+    Fm::ThumbnailJob::setMaxThumbnailFileSize(size);
   }
 
   bool showSidePane() const {
@@ -215,7 +224,7 @@ private:
   bool showOutline_;
   bool showAnnotationsToolbar_;
   bool forceZoomFit_;
-  
+
   QSize prefSize_;
 
   QHash<QString, QString> actions_;

--- a/src/upload/upload.cpp
+++ b/src/upload/upload.cpp
@@ -36,9 +36,15 @@ Upload::Upload(QNetworkReply *reply)
     });
 
     // Emit error() when a socket error occurs
+#if (QT_VERSION >= QT_VERSION_CHECK(5,15,0))
+    connect(mReply, &QNetworkReply::errorOccurred, [this](QNetworkReply::NetworkError) {
+        Q_EMIT error(mReply->errorString());
+    });
+#else
     connect(mReply, static_cast<void(QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error), [this](QNetworkReply::NetworkError) {
         Q_EMIT error(mReply->errorString());
     });
+#endif
 
     // Process the request when it finishes
     connect(mReply, &QNetworkReply::finished, [this]() {


### PR DESCRIPTION
Two options are added: showing thumbnails dock by default and setting the max. file size for creating thumbnails.

No option is added for disabling thumbnails because this is an image viewer.

Also, silenced two compilation warnings about `QNetworkReply::error` and `QMatrix` and changed a bad translatable string that was added in https://github.com/lxqt/lximage-qt/commit/502530154d61d9e46213908292ecc8a7c0e0520c