### PR TITLE
Try best to raise new windows

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -35,6 +35,7 @@
 #include <QMouseEvent>
 #include <QTimer>
 #include <QScreen>
+#include <QWindow>
 #include <QShortcut>
 #include <QDockWidget>
 #include <QScrollBar>
@@ -597,7 +598,7 @@ void MainWindow::onImageLoaded() {
       if(startMaximized_) {
         setWindowState(windowState() | Qt::WindowMaximized);
       }
-      show();
+      showAndRaise();
     }
   }
 }
@@ -811,7 +812,7 @@ void MainWindow::loadImage(const Fm::FilePath & filePath, QModelIndex index) {
       if(startMaximized_) {
         setWindowState(windowState() | Qt::WindowMaximized);
       }
-      show();
+      showAndRaise();
     }
   }
   else {
@@ -1440,4 +1441,15 @@ void MainWindow::deleteOpenWithMenu() {
   if(fileMenu_) {
     fileMenu_->deleteLater();
   }
+}
+
+void MainWindow::showAndRaise() {
+    show();
+    raise();
+    activateWindow();
+    QTimer::singleShot(100, this, [this]() { // steal the focus forcefully
+        if(QWindow *win = windowHandle()) {
+            win->requestActivate();
+        }
+    });
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -153,6 +153,7 @@ private:
   void updateUI();
   void setModified(bool modified);
   QModelIndex indexFromPath(const Fm::FilePath & filePath);
+  void showAndRaise();
 
 private:
   Ui::MainWindow ui;


### PR DESCRIPTION
And override WM focus stealing prevention as far as possible.

NOTE: This doesn't work under Wayland but Wayland's impractical situation can't be our concern.

Closes https://github.com/lxqt/lximage-qt/issues/427