### PR TITLE
Fixed bugs in image fitting, especially with thumbnail dock

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -244,7 +244,9 @@ void ImageView::zoomFit() {
     // instead of scaling it up.
     if(static_cast<int>(image_.width() / qApp->devicePixelRatio()) <= width()
        && static_cast<int>(image_.height() / qApp->devicePixelRatio()) <= height()) {
+      bool tmp = autoZoomFit_; // should be restored because it may be changed below
       zoomOriginal();
+      autoZoomFit_ = tmp;
       return;
     }
   }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -147,6 +147,7 @@ MainWindow::MainWindow():
   contextMenu_->addAction(ui.actionSlideShow);
   contextMenu_->addAction(ui.actionFullScreen);
   contextMenu_->addAction(ui.actionShowOutline);
+  contextMenu_->addAction(ui.actionShowThumbnails);
   contextMenu_->addAction(ui.actionAnnotations);
   contextMenu_->addSeparator();
   contextMenu_->addAction(ui.actionRotateClockwise);
@@ -1210,6 +1211,10 @@ void MainWindow::setShowThumbnails(bool show) {
       connect(thumbnailsView_->selectionModel(), &QItemSelectionModel::selectionChanged,
               this, &MainWindow::onThumbnailSelChanged);
     }
+    else if (!thumbnailsDock_->isVisible()) {
+      thumbnailsDock_->show();
+      ui.actionShowThumbnails->setChecked(true);
+    }
   }
   else {
     if(thumbnailsDock_) {
@@ -1283,8 +1288,12 @@ void MainWindow::changeEvent(QEvent* event) {
       ui.toolBar->hide();
       ui.annotationsToolBar->hide();
       ui.statusBar->hide();
-      if(thumbnailsDock_)
+      // It's logical to hide the thumbnail dock on full-screening. The user could show it
+      // in the full-screen mode explicitly.
+      if(thumbnailsDock_) {
         thumbnailsDock_->hide();
+        ui.actionShowThumbnails->setChecked(false);
+      }
       // NOTE: in fullscreen mode, all shortcut keys in the menu are disabled since the menu
       // is disabled. We needs to add the actions to the main window manually to enable the
       // shortcuts again.
@@ -1313,8 +1322,11 @@ void MainWindow::changeEvent(QEvent* event) {
           ui.annotationsToolBar->show();
       }
       ui.statusBar->show();
-      if(thumbnailsDock_)
+      if(thumbnailsDock_) {
+        // The thumbnail dock exists but was hidden on full-screening. So, it should be restored.
         thumbnailsDock_->show();
+        ui.actionShowThumbnails->setChecked(true);
+      }
       ui.view->hideCursor(false);
     }
   }

--- a/src/org.lxde.LxImage.Application.xml
+++ b/src/org.lxde.LxImage.Application.xml
@@ -6,6 +6,8 @@
     <method name="newWindow">
       <!-- file paths to open in new windows -->
       <arg type="as" direction="in"/>
+      <!-- whether new window should be full screen -->
+      <arg type="b" direction="in"/>
     </method>
 
     <!-- launch a tool to take a screenshot -->


### PR DESCRIPTION
Fixes https://github.com/lxqt/lximage-qt/issues/433 (and more).

Also, added the new argument of introspection data for staring in full-screen mode, which I'd forgotten in https://github.com/lxqt/lximage-qt/commit/8d122f2a48641fa955f0dabbc44035f05d690348