### PR TITLE
Add option to hide/show main toolbar

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -117,6 +117,20 @@ MainWindow::MainWindow():
   setShowThumbnails(settings.showThumbnails());
   ui.actionShowThumbnails->setChecked(settings.showThumbnails());
 
+  ui.toolBar->setVisible(settings.isToolbarShown());
+  ui.actionToolbar->setChecked(settings.isToolbarShown());
+  connect(ui.actionToolbar, &QAction::triggered, this, [this](int checked) {
+    if(!isFullScreen()) { // toolbar is hidden in fullscreen
+      ui.toolBar->setVisible(checked);
+    }
+  });
+  // toolbar visibility can change in its context menu
+  connect(ui.toolBar, &QToolBar::visibilityChanged, this, [this](int visible) {
+    if(!isFullScreen()) { // toolbar is hidden in fullscreen
+      ui.actionToolbar->setChecked(visible);
+    }
+  });
+
   ui.annotationsToolBar->setVisible(settings.isAnnotationsToolbarShown());
   ui.actionAnnotations->setChecked(settings.isAnnotationsToolbarShown());
   connect(ui.actionAnnotations, &QAction::triggered, this, [this](int checked) {
@@ -148,6 +162,7 @@ MainWindow::MainWindow():
   contextMenu_->addAction(ui.actionFullScreen);
   contextMenu_->addAction(ui.actionShowOutline);
   contextMenu_->addAction(ui.actionShowThumbnails);
+  contextMenu_->addAction(ui.actionToolbar);
   contextMenu_->addAction(ui.actionAnnotations);
   contextMenu_->addSeparator();
   contextMenu_->addAction(ui.actionRotateClockwise);
@@ -1317,7 +1332,9 @@ void MainWindow::changeEvent(QEvent* event) {
           removeAction(action);
       }
       ui.menubar->show();
-      ui.toolBar->show();
+      if(ui.actionToolbar->isChecked()){
+          ui.toolBar->show();
+      }
       if(ui.actionAnnotations->isChecked()){
           ui.annotationsToolBar->show();
       }

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -121,6 +121,7 @@
     <addaction name="actionFullScreen"/>
     <addaction name="actionSlideShow"/>
     <addaction name="separator"/>
+    <addaction name="actionToolbar"/>
     <addaction name="actionAnnotations"/>
    </widget>
    <widget class="QMenu" name="menu_Edit">
@@ -621,6 +622,17 @@
    </property>
    <property name="toolTip">
     <string>Draw incrementing numbers</string>
+   </property>
+  </action>
+  <action name="actionToolbar">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Main Toolbar</string>
+   </property>
+   <property name="toolTip">
+    <string>Main Toolbar</string>
    </property>
   </action>
   <action name="actionAnnotations">

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -84,6 +84,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   ui.slideShowInterval->setValue(settings.slideShowInterval());
   ui.oulineBox->setChecked(settings.isOutlineShown());
   ui.annotationBox->setChecked(settings.isAnnotationsToolbarShown());
+  ui.toolbarBox->setChecked(settings.isToolbarShown());
   ui.forceZoomFitBox->setChecked(settings.forceZoomFit());
 
   ui.thumbnailBox->setChecked(settings.showThumbnails());
@@ -143,6 +144,7 @@ void PreferencesDialog::accept() {
   settings.setSlideShowInterval(ui.slideShowInterval->value());
   settings.showOutline(ui.oulineBox->isChecked());
   settings.showAnnotationsToolbar(ui.annotationBox->isChecked());
+  settings.showToolbar(ui.toolbarBox->isChecked());
   settings.setForceZoomFit(ui.forceZoomFitBox->isChecked());
 
   settings.setShowThumbnails(ui.thumbnailBox->isChecked());

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -97,13 +97,20 @@
         </widget>
        </item>
        <item row="6" column="0" colspan="2">
+        <widget class="QCheckBox" name="toolbarBox">
+         <property name="text">
+          <string>Show main toolbar by default</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0" colspan="2">
         <widget class="QCheckBox" name="annotationBox">
          <property name="text">
           <string>Show annotations toolbar by default</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="0" colspan="2">
+       <item row="8" column="0" colspan="2">
         <widget class="QCheckBox" name="forceZoomFitBox">
          <property name="text">
           <string>Fit images when navigating</string>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -41,6 +41,7 @@ Settings::Settings():
   lastWindowMaximized_(false),
   showOutline_(false),
   showAnnotationsToolbar_(false),
+  showToolbar_(true),
   forceZoomFit_(false) {
 }
 
@@ -66,6 +67,7 @@ bool Settings::load() {
   rememberWindowSize_ = settings.value(QStringLiteral("RememberWindowSize"), true).toBool();
   showOutline_ = settings.value(QStringLiteral("ShowOutline"), false).toBool();
   showAnnotationsToolbar_ = settings.value(QStringLiteral("ShowAnnotationsToolbar"), false).toBool();
+  showToolbar_ = settings.value(QStringLiteral("ShowToolbar"), true).toBool();
   forceZoomFit_ = settings.value(QStringLiteral("ForceZoomFit"), false).toBool();
   prefSize_ = settings.value(QStringLiteral("PrefSize"), QSize(400, 400)).toSize();
   settings.endGroup();
@@ -106,6 +108,7 @@ bool Settings::save() {
   settings.setValue(QStringLiteral("RememberWindowSize"), rememberWindowSize_);
   settings.setValue(QStringLiteral("ShowOutline"), showOutline_);
   settings.setValue(QStringLiteral("ShowAnnotationsToolbar"), showAnnotationsToolbar_);
+  settings.setValue(QStringLiteral("ShowToolbar"), showToolbar_);
   settings.setValue(QStringLiteral("ForceZoomFit"), forceZoomFit_);
   settings.setValue(QStringLiteral("PrefSize"), prefSize_);
   settings.endGroup();

--- a/src/settings.h
+++ b/src/settings.h
@@ -178,6 +178,14 @@ public:
     showAnnotationsToolbar_ = show;
   }
 
+  bool isToolbarShown() const {
+    return showToolbar_;
+  }
+
+  void showToolbar(bool show) {
+    showToolbar_ = show;
+  }
+
   bool forceZoomFit() const {
     return forceZoomFit_;
   }
@@ -223,6 +231,7 @@ private:
   bool lastWindowMaximized_;
   bool showOutline_;
   bool showAnnotationsToolbar_;
+  bool showToolbar_;
   bool forceZoomFit_;
 
   QSize prefSize_;


### PR DESCRIPTION
It's currently possible to hide the main toolbar using its context menu.  However, to re-show it requires using the context menu from the annotation toolbar.  This makes re-showing the main toolbar a multi-step process (show annotation bar, context menu, show main toolbar, re-hide annotation bar).  This pull request adds the option to hide/show the main toolbar directly.