### PR TITLE
Add option to change Thumbnail dock position

### DIFF
--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -92,6 +92,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   // the max. thumbnail size spinbox is in MiB
   ui.thumbnailSpin->setValue(qBound(0, settings.maxThumbnailFileSize() / 1024, 1024));
   initThumbnailSizes(settings);
+  initThumbnailsPositions(settings);
 
   // shortcuts
   initShortcuts();
@@ -151,6 +152,7 @@ void PreferencesDialog::accept() {
   settings.setUseTrash(ui.useTrashBox->isChecked());
 
   settings.setShowThumbnails(ui.thumbnailBox->isChecked());
+  settings.setThumbnailsPosition(ui.thumbnailsPositionComboBox->currentText());
   // the max. thumbnail size spinbox is in MiB
   settings.setMaxThumbnailFileSize(ui.thumbnailSpin->value() * 1024);
   settings.setThumbnailSize(ui.thumbnailSizeComboBox->itemData(ui.thumbnailSizeComboBox->currentIndex()).toInt());
@@ -191,6 +193,13 @@ void PreferencesDialog::initThumbnailSizes(Settings& settings) {
     }
     ++i;
   }
+}
+
+void PreferencesDialog::initThumbnailsPositions(Settings& settings) {
+  for (auto position : settings.thumbnailsPositions()) {
+    ui.thumbnailsPositionComboBox->addItem(position);
+  }
+  ui.thumbnailsPositionComboBox->setCurrentText(settings.thumbnailsPosition());
 }
 
 void PreferencesDialog::initIconThemes(Settings& settings) {

--- a/src/preferencesdialog.h
+++ b/src/preferencesdialog.h
@@ -73,6 +73,7 @@ private Q_SLOTS:
 private:
   void initIconThemes(Settings& settings);
   void initThumbnailSizes(Settings& settings);
+  void initThumbnailsPositions(Settings& settings);
   void initShortcuts();
   void applyNewShortcuts();
   void showWarning(const QString& text, bool temporary = true);

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -131,12 +131,15 @@
        <string>Thumbnails</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout_2">
-       <item row="0" column="0" colspan="2">
+       <item row="0" column="0">
         <widget class="QCheckBox" name="thumbnailBox">
          <property name="text">
           <string>Show thumbnails dock by default</string>
          </property>
         </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="thumbnailsPositionComboBox"/>
        </item>
        <item row="1" column="0">
         <widget class="QLabel" name="thumbnailLabel">

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -31,6 +31,7 @@ Settings::Settings():
   fullScreenBgColor_(0, 0, 0),
   showThumbnails_(false),
   thumbnailSize_(64),
+  thumbnailsPosition_(QStringLiteral("bottom")),
   showSidePane_(false),
   slideShowInterval_(5),
   fallbackIconTheme_(QStringLiteral("oxygen")),
@@ -86,8 +87,9 @@ bool Settings::load() {
 
   settings.beginGroup(QStringLiteral("Thumbnail"));
   showThumbnails_ = settings.value(QStringLiteral("ShowThumbnails"), false).toBool();
+  setThumbnailsPosition(settings.value(QStringLiteral("ThumbnailsPosition")).toString());
   setMaxThumbnailFileSize(qMax(settings.value(QStringLiteral("MaxThumbnailFileSize"), 4096).toInt(), 1024));
-  thumbnailSize_ = settings.value(QStringLiteral("ThumbnailSize"), 64).toInt();
+  setThumbnailSize(settings.value(QStringLiteral("ThumbnailSize"), 64).toInt());
   settings.endGroup();
 
   return true;
@@ -132,6 +134,7 @@ bool Settings::save() {
 
   settings.beginGroup(QStringLiteral("Thumbnail"));
   settings.setValue(QStringLiteral("ShowThumbnails"), showThumbnails_);
+  settings.setValue(QStringLiteral("ThumbnailsPosition"), thumbnailsPosition_);
   settings.setValue(QStringLiteral("MaxThumbnailFileSize"), maxThumbnailFileSize());
   settings.setValue(QStringLiteral("ThumbnailSize"), thumbnailSize_);
   settings.endGroup();

--- a/src/settings.h
+++ b/src/settings.h
@@ -71,6 +71,37 @@ public:
     showThumbnails_ = show;
   }
 
+  QString thumbnailsPosition() {
+    return thumbnailsPosition_;
+  }
+  void setThumbnailsPosition(const QString& position) {
+    if(!thumbnailsPositions().contains(position)) {
+      thumbnailsPosition_ = QStringLiteral("bottom");
+    }
+    else {
+      thumbnailsPosition_ = position;
+    }
+  }
+  const QStringList& thumbnailsPositions() {
+    static const QStringList _thumbnailsPositions = {QStringLiteral("left"),
+                                                     QStringLiteral("right"),
+                                                     QStringLiteral("top"),
+                                                     QStringLiteral("bottom")};
+    return _thumbnailsPositions;
+  }
+  Qt::DockWidgetArea getThumbnailsPosition() {
+    if(thumbnailsPosition_ == QStringLiteral("left")) {
+      return Qt::LeftDockWidgetArea;
+    }
+    if(thumbnailsPosition_ == QStringLiteral("right")) {
+      return Qt::RightDockWidgetArea;
+    }
+    if(thumbnailsPosition_ == QStringLiteral("top")) {
+      return Qt::TopDockWidgetArea;
+    }
+    return Qt::BottomDockWidgetArea;
+  }
+
   int maxThumbnailFileSize() const {
     return Fm::ThumbnailJob::maxThumbnailFileSize();
   }
@@ -87,7 +118,12 @@ public:
     return thumbnailSize_;
   }
   void setThumbnailSize(int size) {
-    thumbnailSize_ = size;
+    if(!thumbnailSizes().contains(thumbnailSize_)) {
+      thumbnailSize_ = 64;
+    }
+    else {
+      thumbnailSize_ = size;
+    }
   }
 
   bool showSidePane() const {
@@ -236,6 +272,7 @@ private:
   QColor fullScreenBgColor_;
   bool showThumbnails_;
   int thumbnailSize_;
+  QString thumbnailsPosition_;
   bool showSidePane_;
   int slideShowInterval_;
   QString fallbackIconTheme_;


### PR DESCRIPTION
This adds an option to move the Thumbnail dock to different sides of the main window.

![screenshot-thumb-position-2](https://user-images.githubusercontent.com/8353098/131888746-516e41d4-3314-4546-a7a5-1a20c8ec8bc6.jpg)

