### PR TITLE
Add option to show/hide Exif dock at startup

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -114,6 +114,9 @@ MainWindow::MainWindow():
   ui.view->showOutline(settings.isOutlineShown());
   ui.actionShowOutline->setChecked(settings.isOutlineShown());
 
+  setShowExifData(settings.showExifData());
+  ui.actionShowExifData->setChecked(settings.showExifData());
+
   setShowThumbnails(settings.showThumbnails());
   ui.actionShowThumbnails->setChecked(settings.showThumbnails());
 
@@ -161,6 +164,7 @@ MainWindow::MainWindow():
   contextMenu_->addAction(ui.actionSlideShow);
   contextMenu_->addAction(ui.actionFullScreen);
   contextMenu_->addAction(ui.actionShowOutline);
+  contextMenu_->addAction(ui.actionShowExifData);
   contextMenu_->addAction(ui.actionShowThumbnails);
   contextMenu_->addAction(ui.actionToolbar);
   contextMenu_->addAction(ui.actionAnnotations);
@@ -1177,6 +1181,9 @@ void MainWindow::on_actionShowOutline_triggered(bool checked) {
 
 void MainWindow::on_actionShowExifData_triggered(bool checked) {
   setShowExifData(checked);
+  if(checked && exifDataDock_) {
+    exifDataDock_->show(); // needed in the full-screen state
+  }
 }
 
 void MainWindow::setShowThumbnails(bool show) {
@@ -1249,7 +1256,7 @@ void MainWindow::setShowThumbnails(bool show) {
 void MainWindow::setShowExifData(bool show) {
   // Close the dock if it exists and show is false
   if (exifDataDock_ && !show) {
-    exifDataDock_->close();
+    delete exifDataDock_;
     exifDataDock_ = nullptr;
   }
 
@@ -1313,6 +1320,10 @@ void MainWindow::changeEvent(QEvent* event) {
         thumbnailsDock_->hide();
         ui.actionShowThumbnails->setChecked(false);
       }
+      if(exifDataDock_) {
+        exifDataDock_->hide();
+        ui.actionShowExifData->setChecked(false);
+      }
       // NOTE: in fullscreen mode, all shortcut keys in the menu are disabled since the menu
       // is disabled. We needs to add the actions to the main window manually to enable the
       // shortcuts again.
@@ -1347,6 +1358,11 @@ void MainWindow::changeEvent(QEvent* event) {
         // The thumbnail dock exists but was hidden on full-screening. So, it should be restored.
         thumbnailsDock_->show();
         ui.actionShowThumbnails->setChecked(true);
+      }
+      if(exifDataDock_) {
+        // The exif data dock exists but was hidden on full-screening. So, it should be restored.
+        exifDataDock_->show();
+        ui.actionShowExifData->setChecked(true);
       }
       ui.view->hideCursor(false);
     }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -184,9 +184,6 @@ private:
 
   // EXIF Data
   QDockWidget* exifDataDock_ = nullptr;
-  QWidget* exifDataDockView_;
-  QVBoxLayout* exifDataDockViewContent_;
-  QTableWidget* exifDataContentTable_;
 
   QMap<QString, QString> exifData_;
 

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -88,6 +88,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   ui.forceZoomFitBox->setChecked(settings.forceZoomFit());
   ui.useTrashBox->setChecked(settings.useTrash());
 
+  ui.exifDataBox->setChecked(settings.showExifData());
   ui.thumbnailBox->setChecked(settings.showThumbnails());
   // the max. thumbnail size spinbox is in MiB
   ui.thumbnailSpin->setValue(qBound(0, settings.maxThumbnailFileSize() / 1024, 1024));
@@ -151,6 +152,7 @@ void PreferencesDialog::accept() {
   settings.setForceZoomFit(ui.forceZoomFitBox->isChecked());
   settings.setUseTrash(ui.useTrashBox->isChecked());
 
+  settings.setShowExifData(ui.exifDataBox->isChecked());
   settings.setShowThumbnails(ui.thumbnailBox->isChecked());
   settings.setThumbnailsPosition(ui.thumbnailsPositionComboBox->currentText());
   // the max. thumbnail size spinbox is in MiB

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -44,17 +44,17 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Fullscreen background color:</string>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="1">
         <widget class="Fm::ColorButton" name="bgColor">
          <property name="text">
           <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Fullscreen background color:</string>
          </property>
         </widget>
        </item>
@@ -132,23 +132,30 @@
       </attribute>
       <layout class="QFormLayout" name="formLayout_2">
        <item row="0" column="0">
+        <widget class="QCheckBox" name="exifDataBox">
+         <property name="text">
+          <string>Show Exif data dock by default</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
         <widget class="QCheckBox" name="thumbnailBox">
          <property name="text">
           <string>Show thumbnails dock by default</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
+       <item row="1" column="1">
         <widget class="QComboBox" name="thumbnailsPositionComboBox"/>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="thumbnailLabel">
          <property name="text">
           <string>Thumbnailer file size limit:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <widget class="QSpinBox" name="thumbnailSpin">
          <property name="suffix">
           <string> MiB</string>
@@ -164,14 +171,14 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="thumbnailSizeLabel">
          <property name="text">
           <string>Thumbnail image dimensions:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QComboBox" name="thumbnailSizeComboBox"/>
        </item>
       </layout>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -29,6 +29,7 @@ Settings::Settings():
   useFallbackIconTheme_(QIcon::themeName().isEmpty() || QIcon::themeName() == QLatin1String("hicolor")),
   bgColor_(255, 255, 255),
   fullScreenBgColor_(0, 0, 0),
+  showExifData_(false),
   showThumbnails_(false),
   thumbnailSize_(64),
   thumbnailsPosition_(QStringLiteral("bottom")),
@@ -86,6 +87,7 @@ bool Settings::load() {
   settings.endGroup();
 
   settings.beginGroup(QStringLiteral("Thumbnail"));
+  showExifData_ = settings.value(QStringLiteral("ShowExifData"), false).toBool();
   showThumbnails_ = settings.value(QStringLiteral("ShowThumbnails"), false).toBool();
   setThumbnailsPosition(settings.value(QStringLiteral("ThumbnailsPosition")).toString());
   setMaxThumbnailFileSize(qMax(settings.value(QStringLiteral("MaxThumbnailFileSize"), 4096).toInt(), 1024));
@@ -133,6 +135,7 @@ bool Settings::save() {
   settings.endGroup();
 
   settings.beginGroup(QStringLiteral("Thumbnail"));
+  settings.setValue(QStringLiteral("ShowExifData"), showExifData_);
   settings.setValue(QStringLiteral("ShowThumbnails"), showThumbnails_);
   settings.setValue(QStringLiteral("ThumbnailsPosition"), thumbnailsPosition_);
   settings.setValue(QStringLiteral("MaxThumbnailFileSize"), maxThumbnailFileSize());

--- a/src/settings.h
+++ b/src/settings.h
@@ -64,6 +64,13 @@ public:
     fullScreenBgColor_ = color;
   }
 
+  bool showExifData() const {
+    return showExifData_;
+  }
+  void setShowExifData(bool show) {
+    showExifData_ = show;
+  }
+
   bool showThumbnails() const {
     return showThumbnails_;
   }
@@ -270,6 +277,7 @@ private:
   bool useFallbackIconTheme_;
   QColor bgColor_;
   QColor fullScreenBgColor_;
+  bool showExifData_;
   bool showThumbnails_;
   int thumbnailSize_;
   QString thumbnailsPosition_;


### PR DESCRIPTION
This adds an option to preferences to show/hide the Exif dock at startup.