### PR TITLE
Add option to change smoothing method when zooming

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -50,7 +50,9 @@ ImageView::ImageView(QWidget* parent):
   autoZoomFit_(false),
   isSVG(false),
   currentTool(ToolNone),
-  showOutline_(false) {
+  showOutline_(false),
+  scaleEnlargeSmoothing_(Qt::SmoothTransformation),
+  scaleShrinkSmoothing_(Qt::SmoothTransformation) {
 
   setViewportMargins(0, 0, 0, 0);
   setContentsMargins(0, 0, 0, 0);
@@ -557,7 +559,15 @@ void ImageView::generateCache() {
   }
 
   // QImage scaled = subImage.scaled(subRect.width() * scaleFactor_, subRect.height() * scaleFactor_, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-  QImage scaled = subImage.scaled(cachedRect_.size() * qApp->devicePixelRatio(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  QImage scaled;
+  if (viewportImageRect.width() > subRect.width()) {
+    // zooming in
+    scaled = subImage.scaled(cachedRect_.size() * qApp->devicePixelRatio(), Qt::KeepAspectRatio, scaleEnlargeSmoothing());
+  }
+  else {
+    // zooming out
+    scaled = subImage.scaled(cachedRect_.size() * qApp->devicePixelRatio(), Qt::KeepAspectRatio, scaleShrinkSmoothing());
+  }
 
   // convert the cached scaled image to pixmap
   cachedPixmap_ = QPixmap::fromImage(scaled);

--- a/src/imageview.h
+++ b/src/imageview.h
@@ -52,6 +52,30 @@ public:
     return image_;
   }
 
+  static const QStringList& scaleSmoothingMethods() {
+    static const QStringList _smoothingMethods = {QStringLiteral("Fast"),
+                                                  QStringLiteral("Smooth")};
+    return _smoothingMethods;
+  }
+  Qt::TransformationMode getSmoothingMethod(QString method) {
+    if(method == QStringLiteral("Fast")) {
+      return Qt::FastTransformation;
+    }
+    return Qt::SmoothTransformation;
+  }
+  Qt::TransformationMode scaleEnlargeSmoothing() const {
+    return scaleEnlargeSmoothing_;
+  }
+  void setScaleEnlargeSmoothing(QString method) {
+    scaleEnlargeSmoothing_ = getSmoothingMethod(method);
+  }
+  Qt::TransformationMode scaleShrinkSmoothing() const {
+    return scaleShrinkSmoothing_;
+  }
+  void setScaleShrinkSmoothing(QString method) {
+    scaleShrinkSmoothing_ = getSmoothingMethod(method);
+  }
+
   void setScaleFactor(double scale);
 
   double scaleFactor() const {
@@ -140,6 +164,8 @@ private:
   QList<QGraphicsItem *> annotations;	//annotation items which have been drawn in the scene
   int nextNumber;
   bool showOutline_;
+  Qt::TransformationMode scaleEnlargeSmoothing_;
+  Qt::TransformationMode scaleShrinkSmoothing_;
 };
 
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1106,6 +1106,8 @@ void MainWindow::applySettings() {
   else
     ui.view->setBackgroundBrush(QBrush(settings.bgColor()));
   ui.view->updateOutline();
+  ui.view->setScaleEnlargeSmoothing(settings.scaleEnlargeSmoothing());
+  ui.view->setScaleShrinkSmoothing(settings.scaleShrinkSmoothing());
   ui.menuRecently_Opened_Files->setMaxItems(settings.maxRecentFiles());
 
   // also, update shortcuts

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -26,6 +26,7 @@
 #include <QWindow>
 #include <QScreen>
 #include <glib.h>
+#include "imageview.h"
 
 using namespace LxImage;
 
@@ -94,6 +95,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   ui.thumbnailSpin->setValue(qBound(0, settings.maxThumbnailFileSize() / 1024, 1024));
   initThumbnailSizes(settings);
   initThumbnailsPositions(settings);
+  initSmoothingComboBoxes(settings);
 
   // shortcuts
   initShortcuts();
@@ -158,6 +160,8 @@ void PreferencesDialog::accept() {
   // the max. thumbnail size spinbox is in MiB
   settings.setMaxThumbnailFileSize(ui.thumbnailSpin->value() * 1024);
   settings.setThumbnailSize(ui.thumbnailSizeComboBox->itemData(ui.thumbnailSizeComboBox->currentIndex()).toInt());
+  settings.setScaleEnlargeSmoothing(ui.scaleEnlargeSmoothingComboBox->currentText());
+  settings.setScaleShrinkSmoothing(ui.scaleShrinkSmoothingComboBox->currentText());
 
   applyNewShortcuts();
   settings.save();
@@ -202,6 +206,15 @@ void PreferencesDialog::initThumbnailsPositions(Settings& settings) {
     ui.thumbnailsPositionComboBox->addItem(position);
   }
   ui.thumbnailsPositionComboBox->setCurrentText(settings.thumbnailsPosition());
+}
+
+void PreferencesDialog::initSmoothingComboBoxes(Settings& settings) {
+  for (auto smoothing : ImageView::scaleSmoothingMethods()) {
+    ui.scaleEnlargeSmoothingComboBox->addItem(smoothing);
+    ui.scaleShrinkSmoothingComboBox->addItem(smoothing);
+  }
+  ui.scaleEnlargeSmoothingComboBox->setCurrentText(settings.scaleEnlargeSmoothing());
+  ui.scaleShrinkSmoothingComboBox->setCurrentText(settings.scaleShrinkSmoothing());
 }
 
 void PreferencesDialog::initIconThemes(Settings& settings) {

--- a/src/preferencesdialog.h
+++ b/src/preferencesdialog.h
@@ -74,6 +74,7 @@ private:
   void initIconThemes(Settings& settings);
   void initThumbnailSizes(Settings& settings);
   void initThumbnailsPositions(Settings& settings);
+  void initSmoothingComboBoxes(Settings& settings);
   void initShortcuts();
   void applyNewShortcuts();
   void showWarning(const QString& text, bool temporary = true);

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -166,6 +166,26 @@
          </property>
         </widget>
        </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="scaleEnlargeSmoothingLabel">
+         <property name="text">
+          <string>Zoom-in scale method:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="scaleEnlargeSmoothingComboBox"/>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="scaleShrinkSmoothingLabel">
+         <property name="text">
+          <string>Zoom-out scale method:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="scaleShrinkSmoothingComboBox"/>
+       </item>
        <item row="4" column="0">
         <widget class="QLabel" name="label_2c">
          <property name="text">

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -33,6 +33,8 @@ Settings::Settings():
   showThumbnails_(false),
   thumbnailSize_(64),
   thumbnailsPosition_(QStringLiteral("bottom")),
+  scaleEnlargeSmoothing_(QStringLiteral("Smooth")),
+  scaleShrinkSmoothing_(QStringLiteral("Smooth")),
   showSidePane_(false),
   slideShowInterval_(5),
   fallbackIconTheme_(QStringLiteral("oxygen")),
@@ -78,6 +80,11 @@ bool Settings::load() {
   prefSize_ = settings.value(QStringLiteral("PrefSize"), QSize(400, 400)).toSize();
   settings.endGroup();
 
+  settings.beginGroup(QStringLiteral("Image"));
+  scaleEnlargeSmoothing_ = settings.value(QStringLiteral("ScaleEnlargeSmoothing"), QStringLiteral("Smooth")).toString();
+  scaleShrinkSmoothing_ = settings.value(QStringLiteral("ScaleShrinkSmoothing"), QStringLiteral("Smooth")).toString();
+  settings.endGroup();
+
   // shortcuts
   settings.beginGroup(QStringLiteral("Shortcuts"));
   const QStringList actions = settings.childKeys();
@@ -121,6 +128,11 @@ bool Settings::save() {
   settings.setValue(QStringLiteral("ForceZoomFit"), forceZoomFit_);
   settings.setValue(QStringLiteral("UseTrash"), useTrash_);
   settings.setValue(QStringLiteral("PrefSize"), prefSize_);
+  settings.endGroup();
+
+  settings.beginGroup(QStringLiteral("Image"));
+  settings.setValue(QStringLiteral("ScaleEnlargeSmoothing"), scaleEnlargeSmoothing_);
+  settings.setValue(QStringLiteral("ScaleShrinkSmoothing"), scaleShrinkSmoothing_);
   settings.endGroup();
 
   // shortcuts

--- a/src/settings.h
+++ b/src/settings.h
@@ -133,6 +133,20 @@ public:
     }
   }
 
+  QString scaleEnlargeSmoothing() const {
+    return scaleEnlargeSmoothing_;
+  }
+  void setScaleEnlargeSmoothing(QString type) {
+    scaleEnlargeSmoothing_ = type;
+  }
+
+  QString scaleShrinkSmoothing() const {
+    return scaleShrinkSmoothing_;
+  }
+  void setScaleShrinkSmoothing(QString type) {
+    scaleShrinkSmoothing_ = type;
+  }
+
   bool showSidePane() const {
     return showSidePane_;
   }
@@ -281,6 +295,8 @@ private:
   bool showThumbnails_;
   int thumbnailSize_;
   QString thumbnailsPosition_;
+  QString scaleEnlargeSmoothing_;
+  QString scaleShrinkSmoothing_;
   bool showSidePane_;
   int slideShowInterval_;
   QString fallbackIconTheme_;


### PR DESCRIPTION
This adds options to change the smoothing method (Fast, Smooth) when zooming.  This addresses #386.

![screenshot-10-scaling](https://user-images.githubusercontent.com/8353098/132102543-9263af82-4f05-403c-984a-90688873ed53.png)