### PR TITLE
Hide dock titlebars

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1191,9 +1191,9 @@ void MainWindow::setShowThumbnails(bool show) {
 
   if(show) {
     if(!thumbnailsDock_) {
-      thumbnailsDock_ = new QDockWidget(this);
+      thumbnailsDock_ = new QDockWidget(tr("Thumbnails"), this);
+      thumbnailsDock_->setTitleBarWidget(new QWidget); // hide dock titlebar
       thumbnailsDock_->setFeatures(QDockWidget::NoDockWidgetFeatures); // FIXME: should use DockWidgetClosable
-      thumbnailsDock_->setWindowTitle(tr("Thumbnails"));
       thumbnailsView_ = new Fm::FolderView(Fm::FolderView::IconMode);
       thumbnailsView_->setIconSize(Fm::FolderView::IconMode, QSize(settings.thumbnailSize(), settings.thumbnailSize()));
       thumbnailsView_->setAutoSelectionDelay(0);
@@ -1263,6 +1263,7 @@ void MainWindow::setShowExifData(bool show) {
   // Be sure the dock was created before rendering content to it
   if (show && !exifDataDock_) {
     exifDataDock_ = new QDockWidget(tr("EXIF Data"), this);
+    exifDataDock_->setTitleBarWidget(new QWidget); // hide dock titlebar
     exifDataDock_->setFeatures(QDockWidget::NoDockWidgetFeatures);
     addDockWidget(Qt::RightDockWidgetArea, exifDataDock_);
   }


### PR DESCRIPTION
The dock functions are self-explanatory when filled.  This hides the dock titles to save a small amount of vertical screen space.