### PR TITLE
Allow creation of shortcut to rename image directly

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -50,6 +50,7 @@
 #include <libfm-qt/filepropsdialog.h>
 #include <libfm-qt/fileoperation.h>
 #include <libfm-qt/folderitemdelegate.h>
+#include <libfm-qt/utilities.h>
 
 #include "mrumenu.h"
 #include "resizeimagedialog.h"
@@ -936,6 +937,27 @@ void MainWindow::on_actionCopyPath_triggered() {
   if(currentFile_) {
     const Fm::CStrPtr dispName = currentFile_.displayName();
     QApplication::clipboard()->setText(QString::fromUtf8(dispName.get()));
+  }
+}
+
+void MainWindow::on_actionRenameFile_triggered() {
+  if(!currentFile_) {
+    return;
+  }
+  currentIndex_ = indexFromPath(currentFile_);
+  if (!currentIndex_.isValid()) {
+    return;
+  }
+  if (thumbnailsView_ && thumbnailsView_->isVisible()) {
+    QAbstractItemView* view = thumbnailsView_->childView();
+    view->scrollTo(currentIndex_);
+    view->edit(currentIndex_);
+    return;
+  }
+  if (currentIndex_.isValid()) {
+    auto file = proxyModel_->fileInfoFromIndex(currentIndex_);
+    Fm::renameFile(file, nullptr);
+    return;
   }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -114,6 +114,7 @@ private Q_SLOTS:
   void on_actionResize_triggered();
   void on_actionCopy_triggered();
   void on_actionCopyPath_triggered();
+  void on_actionRenameFile_triggered();
   void on_actionPaste_triggered();
   void on_actionUpload_triggered();
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -138,6 +138,7 @@
     <addaction name="actionPaste"/>
     <addaction name="separator"/>
     <addaction name="actionCopyPath"/>
+    <addaction name="actionRenameFile"/>
     <addaction name="separator"/>
     <addaction name="actionUpload"/>
     <addaction name="separator"/>
@@ -669,6 +670,17 @@
    </property>
    <property name="toolTip">
     <string>Copy path</string>
+   </property>
+  </action>
+  <action name="actionRenameFile">
+   <property name="icon">
+    <iconset theme="edit-rename"/>
+   </property>
+   <property name="text">
+    <string>Rename</string>
+   </property>
+   <property name="toolTip">
+    <string>Rename</string>
    </property>
   </action>
   <action name="actionResize">


### PR DESCRIPTION
Currently, the only way to create a shortcut to rename a file is to use the File Properties dialog.  This change allows direct access to inline renaming when the thumbnail bar is visible.  When thumbnails are not visible, the libfm-qt rename dialog is shown.