### PR TITLE
Add option to show/hide menubar

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -121,6 +121,7 @@
     <addaction name="actionFullScreen"/>
     <addaction name="actionSlideShow"/>
     <addaction name="separator"/>
+    <addaction name="actionMenubar"/>
     <addaction name="actionToolbar"/>
     <addaction name="actionAnnotations"/>
    </widget>
@@ -625,6 +626,20 @@
     <string>Draw incrementing numbers</string>
    </property>
   </action>
+  <action name="actionMenubar">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Menubar</string>
+   </property>
+   <property name="toolTip">
+    <string>Menubar</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+M</string>
+   </property>
+  </action>
   <action name="actionToolbar">
    <property name="checkable">
     <bool>true</bool>
@@ -681,6 +696,9 @@
    </property>
    <property name="toolTip">
     <string>Rename</string>
+   </property>
+   <property name="shortcut">
+    <string>F2</string>
    </property>
   </action>
   <action name="actionResize">

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -83,8 +83,9 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   ui.maxRecentFiles->setValue(settings.maxRecentFiles());
   ui.slideShowInterval->setValue(settings.slideShowInterval());
   ui.oulineBox->setChecked(settings.isOutlineShown());
-  ui.annotationBox->setChecked(settings.isAnnotationsToolbarShown());
+  ui.menubarBox->setChecked(settings.isMenubarShown());
   ui.toolbarBox->setChecked(settings.isToolbarShown());
+  ui.annotationBox->setChecked(settings.isAnnotationsToolbarShown());
   ui.forceZoomFitBox->setChecked(settings.forceZoomFit());
   ui.useTrashBox->setChecked(settings.useTrash());
 
@@ -147,8 +148,9 @@ void PreferencesDialog::accept() {
   settings.setMaxRecentFiles(ui.maxRecentFiles->value());
   settings.setSlideShowInterval(ui.slideShowInterval->value());
   settings.showOutline(ui.oulineBox->isChecked());
-  settings.showAnnotationsToolbar(ui.annotationBox->isChecked());
+  settings.showMenubar(ui.menubarBox->isChecked());
   settings.showToolbar(ui.toolbarBox->isChecked());
+  settings.showAnnotationsToolbar(ui.annotationBox->isChecked());
   settings.setForceZoomFit(ui.forceZoomFitBox->isChecked());
   settings.setUseTrash(ui.useTrashBox->isChecked());
 

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -114,6 +114,13 @@
          </property>
         </widget>
        </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="menubarBox">
+         <property name="text">
+          <string>Show menubar by default</string>
+         </property>
+        </widget>
+       </item>
        <item row="3" column="0">
         <widget class="QCheckBox" name="toolbarBox">
          <property name="text">

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -43,8 +43,9 @@ Settings::Settings():
   lastWindowHeight_(480),
   lastWindowMaximized_(false),
   showOutline_(false),
-  showAnnotationsToolbar_(false),
+  showMenubar_(true),
   showToolbar_(true),
+  showAnnotationsToolbar_(false),
   forceZoomFit_(false),
   useTrash_(true) {
 }
@@ -70,9 +71,10 @@ bool Settings::load() {
   lastWindowMaximized_ = settings.value(QStringLiteral("LastWindowMaximized"), false).toBool();
   rememberWindowSize_ = settings.value(QStringLiteral("RememberWindowSize"), true).toBool();
   showOutline_ = settings.value(QStringLiteral("ShowOutline"), false).toBool();
-  showAnnotationsToolbar_ = settings.value(QStringLiteral("ShowAnnotationsToolbar"), false).toBool();
   showExifData_ = settings.value(QStringLiteral("ShowExifData"), false).toBool();
+  showMenubar_ = settings.value(QStringLiteral("ShowMenubar"), true).toBool();
   showToolbar_ = settings.value(QStringLiteral("ShowToolbar"), true).toBool();
+  showAnnotationsToolbar_ = settings.value(QStringLiteral("ShowAnnotationsToolbar"), false).toBool();
   forceZoomFit_ = settings.value(QStringLiteral("ForceZoomFit"), false).toBool();
   useTrash_ = settings.value(QStringLiteral("UseTrash"), true).toBool();
   prefSize_ = settings.value(QStringLiteral("PrefSize"), QSize(400, 400)).toSize();
@@ -115,9 +117,10 @@ bool Settings::save() {
   settings.setValue(QStringLiteral("LastWindowMaximized"), lastWindowMaximized_);
   settings.setValue(QStringLiteral("RememberWindowSize"), rememberWindowSize_);
   settings.setValue(QStringLiteral("ShowOutline"), showOutline_);
+  settings.setValue(QStringLiteral("ShowMenubar"), showMenubar_);
+  settings.setValue(QStringLiteral("ShowToolbar"), showToolbar_);
   settings.setValue(QStringLiteral("ShowAnnotationsToolbar"), showAnnotationsToolbar_);
   settings.setValue(QStringLiteral("ShowExifData"), showExifData_);
-  settings.setValue(QStringLiteral("ShowToolbar"), showToolbar_);
   settings.setValue(QStringLiteral("ForceZoomFit"), forceZoomFit_);
   settings.setValue(QStringLiteral("UseTrash"), useTrash_);
   settings.setValue(QStringLiteral("PrefSize"), prefSize_);

--- a/src/settings.h
+++ b/src/settings.h
@@ -224,20 +224,27 @@ public:
     showOutline_ = show;
   }
 
-  bool isAnnotationsToolbarShown() const {
-    return showAnnotationsToolbar_;
-  }
-
-  void showAnnotationsToolbar(bool show) {
-    showAnnotationsToolbar_ = show;
-  }
-
   bool isToolbarShown() const {
     return showToolbar_;
   }
 
   void showToolbar(bool show) {
     showToolbar_ = show;
+  }
+
+  bool isMenubarShown() const {
+    return showMenubar_;
+  }
+  void showMenubar(bool show) {
+    showMenubar_ = show;
+  }
+
+  bool isAnnotationsToolbarShown() const {
+    return showAnnotationsToolbar_;
+  }
+
+  void showAnnotationsToolbar(bool show) {
+    showAnnotationsToolbar_ = show;
   }
 
   bool forceZoomFit() const {
@@ -294,8 +301,9 @@ private:
   int lastWindowHeight_;
   bool lastWindowMaximized_;
   bool showOutline_;
-  bool showAnnotationsToolbar_;
+  bool showMenubar_;
   bool showToolbar_;
+  bool showAnnotationsToolbar_;
   bool forceZoomFit_;
   bool useTrash_;
 


### PR DESCRIPTION
This is just the final feature needed for a "minimal" interface (#283 and #284).  There is no option in the menubar to hide the menubar because hiding it that way may confuse users who don't know how to restore it.  There is a context menu option and default shortcut Ctrl+M so that the menu may be restored when it is hidden.

I also assigned a default shortcut for renaming, since I had overlooked that earlier.