### PR TITLE
Add single window mode

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -78,7 +78,16 @@ public:
     showFullScreen_ = value;
   }
 
+  static MainWindow* lastActive() {
+    return lastActive_;
+  }
+
+  void showStatus(QString text, int duration = 2500) {
+    ui.statusBar->showMessage(text, duration);
+  }
+
 protected:
+  bool event(QEvent* event) override;
   void loadImage(const Fm::FilePath & filePath, QModelIndex index = QModelIndex());
   void saveImage(const Fm::FilePath & filePath); // save current image to a file
   void loadFolder(const Fm::FilePath & newFolderPath);
@@ -161,6 +170,7 @@ private:
   QModelIndex indexFromPath(const Fm::FilePath & filePath);
 
 private:
+  static QPointer<MainWindow> lastActive_;
   Ui::MainWindow ui;
   QMenu* contextMenu_;
   QTimer* slideShowTimer_;

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -88,6 +88,8 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   ui.annotationBox->setChecked(settings.isAnnotationsToolbarShown());
   ui.forceZoomFitBox->setChecked(settings.forceZoomFit());
   ui.useTrashBox->setChecked(settings.useTrash());
+  ui.singleWindowModeBox->setChecked(settings.singleWindowMode());
+  connect(ui.singleWindowModeBox, &QCheckBox::toggled, this, &PreferencesDialog::onSingleWindowModeChange);
 
   ui.exifDataBox->setChecked(settings.showExifData());
   ui.thumbnailBox->setChecked(settings.showThumbnails());
@@ -153,6 +155,7 @@ void PreferencesDialog::accept() {
   settings.showAnnotationsToolbar(ui.annotationBox->isChecked());
   settings.setForceZoomFit(ui.forceZoomFitBox->isChecked());
   settings.setUseTrash(ui.useTrashBox->isChecked());
+  settings.setSingleWindowMode(ui.singleWindowModeBox->isChecked());
 
   settings.setShowExifData(ui.exifDataBox->isChecked());
   settings.setShowThumbnails(ui.thumbnailBox->isChecked());
@@ -246,7 +249,7 @@ void PreferencesDialog::initIconThemes(Settings& settings) {
   }
 }
 
-void PreferencesDialog::showWarning(const QString& text, bool temporary) {
+void PreferencesDialog::showWarning(const QString& text, int delay) {
   if(text.isEmpty()) {
     permanentWarning_.clear();
     ui.warningLabel->clear();
@@ -255,7 +258,7 @@ void PreferencesDialog::showWarning(const QString& text, bool temporary) {
   else {
     ui.warningLabel->setText(text);
     ui.warningLabel->show();
-    if(!temporary) {
+    if(delay < 1) {
       permanentWarning_ = text;
     }
     else {
@@ -267,8 +270,17 @@ void PreferencesDialog::showWarning(const QString& text, bool temporary) {
           ui.warningLabel->setVisible(!permanentWarning_.isEmpty());
         });
       }
-      warningTimer_->start(2500);
+      warningTimer_->start(delay);
     }
+  }
+}
+
+void PreferencesDialog::onSingleWindowModeChange(bool checked) {
+  if(checked) {
+    showWarning(tr("<b>Single window mode: Only one image will be opened at a time.</b>"), 5000);
+  }
+  else {
+    showWarning(QString());
   }
 }
 
@@ -320,7 +332,7 @@ void PreferencesDialog::initShortcuts() {
   const auto shortcuts = allShortcuts_.values();
   for(int i = 0; i < shortcuts.size(); ++i) {
     if(!shortcuts.at(i).isEmpty() && shortcuts.indexOf(shortcuts.at(i), i + 1) > -1) {
-      showWarning(tr("<b>Warning: Ambiguous shortcut detected!</b>"), false);
+      showWarning(tr("<b>Warning: Ambiguous shortcut detected!</b>"), 0);
       break;
     }
   }

--- a/src/preferencesdialog.h
+++ b/src/preferencesdialog.h
@@ -69,6 +69,7 @@ protected:
 private Q_SLOTS:
   void onShortcutChange(QTableWidgetItem* item);
   void restoreDefaultShortcuts();
+  void onSingleWindowModeChange(bool checked);
 
 private:
   void initIconThemes(Settings& settings);
@@ -76,7 +77,7 @@ private:
   void initThumbnailsPositions(Settings& settings);
   void initShortcuts();
   void applyNewShortcuts();
-  void showWarning(const QString& text, bool temporary = true);
+  void showWarning(const QString& text, int delay = 2500);
 
 private:
   Ui::PreferencesDialog ui;

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -80,7 +80,7 @@
        <item row="3" column="1">
         <widget class="QComboBox" name="thumbnailSizeComboBox"/>
        </item>
-       <item row="4" column="0">
+       <item row="4" column="0" colspan="2">
         <widget class="QCheckBox" name="useTrashBox">
          <property name="text">
           <string>Use system Trash (and do not prompt)</string>
@@ -107,31 +107,41 @@
        <item row="0" column="1">
         <widget class="QComboBox" name="thumbnailsPositionComboBox"/>
        </item>
-       <item row="1" column="0">
+       <item row="1" column="0" colspan="2">
         <widget class="QCheckBox" name="exifDataBox">
          <property name="text">
           <string>Show Exif data dock by default</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="2" column="0" colspan="2">
         <widget class="QCheckBox" name="menubarBox">
          <property name="text">
           <string>Show menubar by default</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="3" column="0" colspan="2">
         <widget class="QCheckBox" name="toolbarBox">
          <property name="text">
           <string>Show main toolbar by default</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="4" column="0" colspan="2">
         <widget class="QCheckBox" name="annotationBox">
          <property name="text">
           <string>Show annotations toolbar by default</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="QCheckBox" name="singleWindowModeBox">
+         <property name="toolTip">
+          <string>Only one image will be opened at a time</string>
+         </property>
+         <property name="text">
+          <string>Single window mode</string>
          </property>
         </widget>
        </item>
@@ -187,14 +197,14 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="5" column="0" colspan="2">
         <widget class="QCheckBox" name="oulineBox">
          <property name="text">
           <string>Show image outline by default</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="6" column="0" colspan="2">
         <widget class="QCheckBox" name="forceZoomFitBox">
          <property name="text">
           <string>Fit images when navigating</string>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -47,7 +47,8 @@ Settings::Settings():
   showToolbar_(true),
   showAnnotationsToolbar_(false),
   forceZoomFit_(false),
-  useTrash_(true) {
+  useTrash_(true),
+  singleWindowMode_(false) {
 }
 
 Settings::~Settings() {
@@ -77,6 +78,7 @@ bool Settings::load() {
   showAnnotationsToolbar_ = settings.value(QStringLiteral("ShowAnnotationsToolbar"), false).toBool();
   forceZoomFit_ = settings.value(QStringLiteral("ForceZoomFit"), false).toBool();
   useTrash_ = settings.value(QStringLiteral("UseTrash"), true).toBool();
+  singleWindowMode_ = settings.value(QStringLiteral("SingleWindowMode"), false).toBool();
   prefSize_ = settings.value(QStringLiteral("PrefSize"), QSize(400, 400)).toSize();
   settings.endGroup();
 
@@ -123,6 +125,7 @@ bool Settings::save() {
   settings.setValue(QStringLiteral("ShowExifData"), showExifData_);
   settings.setValue(QStringLiteral("ForceZoomFit"), forceZoomFit_);
   settings.setValue(QStringLiteral("UseTrash"), useTrash_);
+  settings.setValue(QStringLiteral("SingleWindowMode"), singleWindowMode_);
   settings.setValue(QStringLiteral("PrefSize"), prefSize_);
   settings.endGroup();
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -262,6 +262,13 @@ public:
     useTrash_ = on;
   }
 
+  bool singleWindowMode() const {
+    return singleWindowMode_;
+  }
+  void setSingleWindowMode(bool singleWindowMode) {
+    singleWindowMode_ = singleWindowMode;
+  }
+
   QSize getPrefSize() const {
     return prefSize_;
   }
@@ -306,6 +313,7 @@ private:
   bool showAnnotationsToolbar_;
   bool forceZoomFit_;
   bool useTrash_;
+  bool singleWindowMode_;
 
   QSize prefSize_;
 


### PR DESCRIPTION
Borrowed from pcmanfm-qt "Single window mode".  Only one window and one image will be opened at a time.  A prominent warning is displayed so users will be aware of what happens when they use this option.

![screenshot-single-window](https://user-images.githubusercontent.com/8353098/132425717-21f78557-c2d7-4cf9-a0bd-75ec5548a109.png)
