### PR TITLE
Open multiple images when dropped

### DIFF
--- a/src/graphicsscene.cpp
+++ b/src/graphicsscene.cpp
@@ -21,6 +21,7 @@
 #include "graphicsscene.h"
 #include <QMimeData>
 #include <QUrl>
+#include <QDir>
 
 namespace LxImage {
 
@@ -39,10 +40,24 @@ void GraphicsScene::dragMoveEvent(QGraphicsSceneDragDropEvent *event) {
 }
 
 void GraphicsScene::dropEvent(QGraphicsSceneDragDropEvent* event) {
-  QList<QUrl> urlList = event->mimeData()->urls();
-  if(!urlList.isEmpty())
-    Q_EMIT fileDropped(urlList.first().toLocalFile());
-  event->acceptProposedAction();
+  const QMimeData *mimeData = event->mimeData();
+
+  if (mimeData->hasUrls()) {
+    QStringList pathList;
+    QList<QUrl> urlList = mimeData->urls();
+
+    // extract the local paths of the files
+    for (QUrl url : urlList) {
+      if (url.isLocalFile()) {
+        pathList.append(QDir::toNativeSeparators(url.toLocalFile()));
+      }
+    }
+
+    if (!pathList.isEmpty()) {
+      Q_EMIT fileDropped(pathList);
+      event->acceptProposedAction();
+    }
+  }
 }
 
 }

--- a/src/graphicsscene.h
+++ b/src/graphicsscene.h
@@ -39,7 +39,7 @@ protected:
   virtual void dropEvent(QGraphicsSceneDragDropEvent* event);
 
 Q_SIGNALS:
-  void fileDropped(const QString file);
+  void fileDropped(const QStringList pathList);
 };
 
 }

--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -93,8 +93,8 @@ QGraphicsItem* ImageView::outlineGraphicsItem() const {
 }
 
 
-void ImageView::onFileDropped(const QString file) {
-    Q_EMIT fileDropped(file);
+void ImageView::onFileDropped(const QStringList pathList) {
+    Q_EMIT fileDropped(pathList);
 }
 
 void ImageView::wheelEvent(QWheelEvent* event) {

--- a/src/imageview.h
+++ b/src/imageview.h
@@ -88,7 +88,7 @@ public:
   void updateOutline();
 
 Q_SIGNALS:
-  void fileDropped(const QString file);
+  void fileDropped(const QStringList pathList);
   void zooming();
 
 protected:
@@ -117,7 +117,7 @@ private:
   void removeAnnotations();
 
 private Q_SLOTS:
-  void onFileDropped(const QString file);
+  void onFileDropped(const QStringList pathList);
   void generateCache();
   void blankCursor();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -207,7 +207,7 @@ MainWindow::MainWindow():
 
   // Open images when MRU items are clicked
   ui.menuRecently_Opened_Files->setMaxItems(settings.maxRecentFiles());
-  connect(ui.menuRecently_Opened_Files, &MruMenu::itemClicked, this, &MainWindow::onFileDropped);
+  connect(ui.menuRecently_Opened_Files, &MruMenu::itemClicked, this, &MainWindow::openImageFile);
 
   // Create an action group for the annotation tools
   QActionGroup *annotationGroup = new QActionGroup(this);
@@ -1510,8 +1510,14 @@ void MainWindow::onFilesRemoved(const Fm::FileInfoList& files) {
   }
 }
 
-void MainWindow::onFileDropped(const QString path) {
-    openImageFile(path);
+void MainWindow::onFileDropped(QStringList pathList) {
+  if (!pathList.isEmpty()) {
+    openImageFile(pathList.takeFirst());
+  }
+  if (!pathList.isEmpty()) {
+    Application* app = static_cast<Application*>(qApp);
+    app->newWindow(pathList, showFullScreen_);    
+  }
 }
 
 void MainWindow::fileMenuAboutToShow() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -148,7 +148,7 @@ private Q_SLOTS:
   void onThumbnailSelChanged(const QItemSelection & selected, const QItemSelection & deselected);
   void onFilesRemoved(const Fm::FileInfoList& files);
 
-  void onFileDropped(const QString path);
+  void onFileDropped(QStringList pathList);
 
   void fileMenuAboutToShow();
   void createOpenWithMenu();


### PR DESCRIPTION
Looks like multi-window mode was broken in the first place.  Here's a fix if you want it, unless it's supposed to only open one file when multiple files are dropped.  If that's the case, I have no idea what you were complaining about with the single-window mode PR.