### PR TITLE
Fixed issues in a recent commit about thumbnails positions

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1252,10 +1252,10 @@ void MainWindow::setShowThumbnails(bool show) {
       thumbnailsView_->setIconSize(Fm::FolderView::IconMode, QSize(settings.thumbnailSize(), settings.thumbnailSize()));
       thumbnailsView_->setAutoSelectionDelay(0);
       thumbnailsDock_->setWidget(thumbnailsView_);
-      addDockWidget(settings.getThumbnailsPosition(), thumbnailsDock_);
+      addDockWidget(settings.thumbnailsPosition(), thumbnailsDock_);
       QListView* listView = static_cast<QListView*>(thumbnailsView_->childView());
       listView->setSelectionMode(QAbstractItemView::SingleSelection);
-      switch (settings.getThumbnailsPosition()) {
+      switch(settings.thumbnailsPosition()) {
         case Qt::LeftDockWidgetArea:
         case Qt::RightDockWidgetArea:
           listView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -1266,7 +1266,6 @@ void MainWindow::setShowThumbnails(bool show) {
             thumbnailsView_->setFixedWidth(delegate->itemSize().width() + 1.5*scrollWidth);
           }
           break;
-
         case Qt::TopDockWidgetArea:
         case Qt::BottomDockWidgetArea:
         default:

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -156,7 +156,7 @@ void PreferencesDialog::accept() {
 
   settings.setShowExifData(ui.exifDataBox->isChecked());
   settings.setShowThumbnails(ui.thumbnailBox->isChecked());
-  settings.setThumbnailsPosition(ui.thumbnailsPositionComboBox->currentText());
+  settings.setThumbnailsPosition(ui.thumbnailsPositionComboBox->itemData(ui.thumbnailsPositionComboBox->currentIndex()).toInt());
   // the max. thumbnail size spinbox is in MiB
   settings.setMaxThumbnailFileSize(ui.thumbnailSpin->value() * 1024);
   settings.setThumbnailSize(ui.thumbnailSizeComboBox->itemData(ui.thumbnailSizeComboBox->currentIndex()).toInt());
@@ -200,10 +200,18 @@ void PreferencesDialog::initThumbnailSizes(Settings& settings) {
 }
 
 void PreferencesDialog::initThumbnailsPositions(Settings& settings) {
-  for (auto position : settings.thumbnailsPositions()) {
-    ui.thumbnailsPositionComboBox->addItem(position);
+  ui.thumbnailsPositionComboBox->addItem(tr("Bottom"), Qt::BottomDockWidgetArea);
+  ui.thumbnailsPositionComboBox->addItem(tr("Top"), Qt::TopDockWidgetArea);
+  ui.thumbnailsPositionComboBox->addItem(tr("Left"), Qt::LeftDockWidgetArea);
+
+  Qt::DockWidgetArea pos = settings.thumbnailsPosition();
+  for(int i = 0; i < ui.thumbnailsPositionComboBox->count(); ++i) {
+    if(ui.thumbnailsPositionComboBox->itemData(i).toInt() == pos) {
+      ui.thumbnailsPositionComboBox->setCurrentIndex(i);
+      return;
+    }
   }
-  ui.thumbnailsPositionComboBox->setCurrentText(settings.thumbnailsPosition());
+  ui.thumbnailsPositionComboBox->setCurrentIndex(0);
 }
 
 void PreferencesDialog::initIconThemes(Settings& settings) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -32,7 +32,7 @@ Settings::Settings():
   showExifData_(false),
   showThumbnails_(false),
   thumbnailSize_(64),
-  thumbnailsPosition_(QStringLiteral("bottom")),
+  thumbnailsPosition_(Qt::BottomDockWidgetArea),
   showSidePane_(false),
   slideShowInterval_(5),
   fallbackIconTheme_(QStringLiteral("oxygen")),
@@ -91,7 +91,7 @@ bool Settings::load() {
 
   settings.beginGroup(QStringLiteral("Thumbnail"));
   showThumbnails_ = settings.value(QStringLiteral("ShowThumbnails"), false).toBool();
-  setThumbnailsPosition(settings.value(QStringLiteral("ThumbnailsPosition")).toString());
+  thumbnailsPositionFromString(settings.value(QStringLiteral("ThumbnailsPosition")).toString());
   setMaxThumbnailFileSize(qMax(settings.value(QStringLiteral("MaxThumbnailFileSize"), 4096).toInt(), 1024));
   setThumbnailSize(settings.value(QStringLiteral("ThumbnailSize"), 64).toInt());
   settings.endGroup();
@@ -140,7 +140,7 @@ bool Settings::save() {
 
   settings.beginGroup(QStringLiteral("Thumbnail"));
   settings.setValue(QStringLiteral("ShowThumbnails"), showThumbnails_);
-  settings.setValue(QStringLiteral("ThumbnailsPosition"), thumbnailsPosition_);
+  settings.setValue(QStringLiteral("ThumbnailsPosition"), thumbnailsPositionToString());
   settings.setValue(QStringLiteral("MaxThumbnailFileSize"), maxThumbnailFileSize());
   settings.setValue(QStringLiteral("ThumbnailSize"), thumbnailSize_);
   settings.endGroup();
@@ -148,4 +148,44 @@ bool Settings::save() {
   return true;
 }
 
+const QList<int>& Settings::thumbnailSizes() const {
+  static const QList<int> _thumbnailSizes = {256, 224, 192, 160, 128, 96, 64};
+  return _thumbnailSizes;
+}
+
+void Settings::setThumbnailsPosition(int pos) {
+  switch(pos) {
+    case Qt::TopDockWidgetArea:
+      thumbnailsPosition_ = Qt::TopDockWidgetArea;
+      break;
+    case Qt::LeftDockWidgetArea:
+      thumbnailsPosition_ = Qt::LeftDockWidgetArea;
+      break;
+    default:
+      thumbnailsPosition_ = Qt::BottomDockWidgetArea;
+  }
+}
+
+QString Settings::thumbnailsPositionToString() const {
+  switch(thumbnailsPosition_) {
+    case Qt::TopDockWidgetArea:
+      return QStringLiteral("top");
+    case Qt::LeftDockWidgetArea:
+      return QStringLiteral("left");
+    default:
+      return QStringLiteral("bottom");
+  }
+}
+
+void Settings::thumbnailsPositionFromString(const QString& str) {
+  if(str == QStringLiteral("top")) {
+    thumbnailsPosition_ = Qt::TopDockWidgetArea;
+    return;
+  }
+  if(str == QStringLiteral("left")) {
+    thumbnailsPosition_ = Qt::LeftDockWidgetArea;
+    return;
+  }
+  thumbnailsPosition_ = Qt::BottomDockWidgetArea;
+}
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -78,36 +78,10 @@ public:
     showThumbnails_ = show;
   }
 
-  QString thumbnailsPosition() {
+  Qt::DockWidgetArea thumbnailsPosition() const {
     return thumbnailsPosition_;
   }
-  void setThumbnailsPosition(const QString& position) {
-    if(!thumbnailsPositions().contains(position)) {
-      thumbnailsPosition_ = QStringLiteral("bottom");
-    }
-    else {
-      thumbnailsPosition_ = position;
-    }
-  }
-  const QStringList& thumbnailsPositions() {
-    static const QStringList _thumbnailsPositions = {QStringLiteral("left"),
-                                                     QStringLiteral("right"),
-                                                     QStringLiteral("top"),
-                                                     QStringLiteral("bottom")};
-    return _thumbnailsPositions;
-  }
-  Qt::DockWidgetArea getThumbnailsPosition() {
-    if(thumbnailsPosition_ == QStringLiteral("left")) {
-      return Qt::LeftDockWidgetArea;
-    }
-    if(thumbnailsPosition_ == QStringLiteral("right")) {
-      return Qt::RightDockWidgetArea;
-    }
-    if(thumbnailsPosition_ == QStringLiteral("top")) {
-      return Qt::TopDockWidgetArea;
-    }
-    return Qt::BottomDockWidgetArea;
-  }
+  void setThumbnailsPosition(int pos);
 
   int maxThumbnailFileSize() const {
     return Fm::ThumbnailJob::maxThumbnailFileSize();
@@ -117,10 +91,7 @@ public:
     Fm::ThumbnailJob::setMaxThumbnailFileSize(size);
   }
 
-  const QList<int>& thumbnailSizes() {
-    static const QList<int> _thumbnailSizes = {256, 224, 192, 160, 128, 96, 64};
-    return _thumbnailSizes;
-  }
+  const QList<int>& thumbnailSizes() const;
   int thumbnailSize() const {
     return thumbnailSize_;
   }
@@ -281,13 +252,17 @@ public:
   }
 
 private:
+  QString thumbnailsPositionToString() const;
+  void thumbnailsPositionFromString(const QString& str);
+
+private:
   bool useFallbackIconTheme_;
   QColor bgColor_;
   QColor fullScreenBgColor_;
   bool showExifData_;
   bool showThumbnails_;
   int thumbnailSize_;
-  QString thumbnailsPosition_;
+  Qt::DockWidgetArea thumbnailsPosition_;
   bool showSidePane_;
   int slideShowInterval_;
   QString fallbackIconTheme_;


### PR DESCRIPTION
Excluded right area (because it's used by EXIF data) and fixed localization of position strings.

@stefonarch, please merge it if your tests show it's OK. After that, you could update translations; my next PR won't add a translatable string.