### PR TITLE
Fixed several issues in rotation and flipping

### DIFF
--- a/src/imageview.h
+++ b/src/imageview.h
@@ -41,9 +41,6 @@ public:
   ImageView(QWidget* parent = nullptr);
   virtual ~ImageView();
 
-  QGraphicsItem* imageGraphicsItem() const;
-  QGraphicsItem* outlineGraphicsItem() const;
-
   void setImage(const QImage& image, bool show = true);
   void setGifAnimation(const QString& fileName);
   void setSVG(const QString& fileName);
@@ -71,6 +68,11 @@ public:
   void setAutoZoomFit(bool value) {
     autoZoomFit_ = value;
   }
+
+  // transformations
+  void rotateImage(bool clockwise);
+  void flipImage(bool horizontal);
+  bool resizeImage(const QSize& newSize);
 
   // if set to true, hides the cursor after 3s of inactivity
   void hideCursor(bool enable);
@@ -102,6 +104,7 @@ protected:
   virtual void paintEvent(QPaintEvent* event);
 
 private:
+  QGraphicsItem* imageGraphicsItem() const;
   void queueGenerateCache();
   QRect viewportToScene(const QRect& rect);
   QRect sceneToViewport(const QRectF& rect);
@@ -114,7 +117,7 @@ private:
                  qreal tipAngle,
                  int tipLen);
 
-  void removeAnnotations();
+  void resetView();
 
 private Q_SLOTS:
   void onFileDropped(const QString file);


### PR DESCRIPTION
Fixed several issues in rotation and flipping

All issues are fixed by:

 1. Resetting transformations when an image is loaded;
 2. Giving the same code structure to flipping and rotation; and
 3. Loading a saved image (lack of this was a bug in itself).

In addition, the code is cleaned up with regard to image transformation and, as a result, other small bugs are also fixed.

Fixes https://github.com/lxqt/lximage-qt/issues/472