### PR TITLE
Apply changes to thumbnail size on the fly

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1153,15 +1153,17 @@ void MainWindow::setShowThumbnails(bool show) {
       addDockWidget(settings.thumbnailsPosition(), thumbnailsDock_);
       QListView* listView = static_cast<QListView*>(thumbnailsView_->childView());
       listView->setSelectionMode(QAbstractItemView::SingleSelection);
+      Fm::FolderItemDelegate* delegate = static_cast<Fm::FolderItemDelegate*>(listView->itemDelegateForColumn(Fm::FolderModel::ColumnFileName));
+      int frameWidth = thumbnailsView_->style()->pixelMetric(QStyle::PM_DefaultFrameWidth, nullptr, thumbnailsView_);
+      int scrollBarExtent = thumbnailsView_->style()->styleHint(QStyle::SH_ScrollBar_Transient, nullptr, thumbnailsView_) ?
+                            0 : thumbnailsView_->style()->pixelMetric(QStyle::PM_ScrollBarExtent);
       switch(settings.thumbnailsPosition()) {
         case Qt::LeftDockWidgetArea:
         case Qt::RightDockWidgetArea:
           listView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
           listView->setFlow(QListView::LeftToRight);
-
-          if(Fm::FolderItemDelegate* delegate = static_cast<Fm::FolderItemDelegate*>(listView->itemDelegateForColumn(Fm::FolderModel::ColumnFileName))) {
-            int scrollWidth = style()->pixelMetric(QStyle::PM_ScrollBarExtent);
-            thumbnailsView_->setFixedWidth(delegate->itemSize().width() + 1.5*scrollWidth);
+          if(delegate) {
+            thumbnailsView_->setFixedWidth(delegate->itemSize().width() + 2 * frameWidth + scrollBarExtent);
           }
           break;
         case Qt::TopDockWidgetArea:
@@ -1169,10 +1171,8 @@ void MainWindow::setShowThumbnails(bool show) {
         default:
           listView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
           listView->setFlow(QListView::TopToBottom);
-
-          if(Fm::FolderItemDelegate* delegate = static_cast<Fm::FolderItemDelegate*>(listView->itemDelegateForColumn(Fm::FolderModel::ColumnFileName))) {
-            int scrollHeight = style()->pixelMetric(QStyle::PM_ScrollBarExtent);
-            thumbnailsView_->setFixedHeight(delegate->itemSize().height() + 1.5*scrollHeight);
+          if(delegate) {
+            thumbnailsView_->setFixedHeight(delegate->itemSize().height() + 2 * frameWidth + scrollBarExtent);
           }
           break;
       }
@@ -1201,6 +1201,31 @@ void MainWindow::setShowThumbnails(bool show) {
       thumbnailsDock_ = nullptr;
     }
     proxyModel_->setShowThumbnails(false);
+  }
+}
+
+void MainWindow::updateThumbnails() {
+  if(thumbnailsView_ == nullptr) {
+    return;
+  }
+  int thumbSize = static_cast<Application*>(qApp)->settings().thumbnailSize();
+  QSize newSize(thumbSize, thumbSize);
+  if(thumbnailsView_->iconSize(Fm::FolderView::IconMode) == newSize) {
+    return;
+  }
+
+  thumbnailsView_->setIconSize(Fm::FolderView::IconMode, newSize);
+  QListView* listView = static_cast<QListView*>(thumbnailsView_->childView());
+  if(Fm::FolderItemDelegate* delegate = static_cast<Fm::FolderItemDelegate*>(listView->itemDelegateForColumn(Fm::FolderModel::ColumnFileName))) {
+    int frameWidth = thumbnailsView_->style()->pixelMetric(QStyle::PM_DefaultFrameWidth, nullptr, thumbnailsView_);
+    int scrollBarExtent = thumbnailsView_->style()->styleHint(QStyle::SH_ScrollBar_Transient, nullptr, thumbnailsView_) ?
+                          0 : thumbnailsView_->style()->pixelMetric(QStyle::PM_ScrollBarExtent);
+    if(listView->flow() == QListView::LeftToRight) {
+      thumbnailsView_->setFixedWidth(delegate->itemSize().width() + 2 * frameWidth + scrollBarExtent);
+    }
+    else {
+      thumbnailsView_->setFixedHeight(delegate->itemSize().height() + 2 * frameWidth + scrollBarExtent);
+    }
   }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -70,6 +70,8 @@ public:
   }
 
   void setShowThumbnails(bool show);
+  void updateThumbnails();
+
   void setShowExifData(bool show);
   void applySettings();
 

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -161,6 +161,7 @@ void PreferencesDialog::accept() {
   settings.setMaxThumbnailFileSize(ui.thumbnailSpin->value() * 1024);
   settings.setThumbnailSize(ui.thumbnailSizeComboBox->itemData(ui.thumbnailSizeComboBox->currentIndex()).toInt());
 
+  updateThumbnails();
   applyNewShortcuts();
   settings.save();
   QDialog::accept();
@@ -409,6 +410,15 @@ void PreferencesDialog::restoreDefaultShortcuts() {
   ui.tableWidget->setCurrentCell(cur, 1);
   connect(ui.tableWidget, &QTableWidget::itemChanged, this, &PreferencesDialog::onShortcutChange);
   ui.defaultButton->setEnabled(false);
+}
+
+void PreferencesDialog::updateThumbnails() {
+  const auto windows = qApp->topLevelWidgets();
+  for(const auto& window : windows) {
+    if(window->inherits("LxImage::MainWindow")) {
+      static_cast<MainWindow*>(window)->updateThumbnails();
+    }
+  }
 }
 
 void PreferencesDialog::applyNewShortcuts() {

--- a/src/preferencesdialog.h
+++ b/src/preferencesdialog.h
@@ -76,6 +76,7 @@ private:
   void initThumbnailsPositions(Settings& settings);
   void initShortcuts();
   void applyNewShortcuts();
+  void updateThumbnails();
   void showWarning(const QString& text, bool temporary = true);
 
 private:


### PR DESCRIPTION
Also, a small mistake in the calculation of thumbnail-bar's height/width is fixed (the frame width wasn't taken into account).

Closes https://github.com/lxqt/lximage-qt/issues/477