### PR TITLE
Allow custom shortcuts to override hard-coded shortcuts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ set(lximage-qt_UIS
     preferencesdialog.ui
     resizeimagedialog.ui
     screenshotdialog.ui
+    shortcuts.ui
 
     upload/uploaddialog.ui
 )

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -166,37 +166,6 @@ MainWindow* Application::createWindow(bool fullscreen) {
   LxImage::MainWindow* window;
   window = new LxImage::MainWindow();
   window->setShowFullScreen(fullscreen);
-
-  // get default shortcuts from the first window
-  if(defaultShortcuts_.isEmpty()) {
-    const auto actions = window->findChildren<QAction*>();
-    for(const auto& action : actions) {
-      if(action->objectName().isEmpty() || action->text().isEmpty()) {
-        continue;
-      }
-      QKeySequence seq = action->shortcut();
-      ShortcutDescription s;
-      s.displayText = action->text().remove(QLatin1Char('&')); // without mnemonics
-      s.shortcut = seq;
-      defaultShortcuts_.insert(action->objectName(), s);
-    }
-  }
-
-  // apply custom shortcuts to this window
-  QHash<QString, QString> ca = settings_.customShortcutActions();
-  const auto actions = window->findChildren<QAction*>();
-  for(const auto& action : actions) {
-    const QString objectName = action->objectName();
-    if(ca.contains(objectName)) {
-      auto shortcut = ca.take(objectName);
-      // custom shortcuts are saved in the PortableText format.
-      action->setShortcut(QKeySequence(shortcut, QKeySequence::PortableText));
-    }
-    if(ca.isEmpty()) {
-      break;
-    }
-  }
-
   return window;
 }
 

--- a/src/application.h
+++ b/src/application.h
@@ -65,6 +65,9 @@ public:
   QHash<QString, ShortcutDescription> defaultShortcuts() const {
     return defaultShortcuts_;
   }
+  void setDefaultShortcuts(QHash<QString, ShortcutDescription> shortcuts) {
+    defaultShortcuts_ = shortcuts;
+  }
 
 public Q_SLOTS:
   void editPreferences();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -235,10 +235,10 @@ MainWindow::MainWindow():
   hardCodedShortcuts_[Qt::Key_Space] = shortcut;
   connect(shortcut, &QShortcut::activated, this, &MainWindow::on_actionNext_triggered);
   shortcut = new QShortcut(this);
-  hardCodedShortcuts_[Qt::ALT | Qt::Key_Backspace] = shortcut;
+  hardCodedShortcuts_[Qt::Key_Home] = shortcut; // already in GUI but will be forced if removed
   connect(shortcut, &QShortcut::activated, this, &MainWindow::on_actionFirst_triggered);
   shortcut = new QShortcut(this);
-  hardCodedShortcuts_[Qt::ALT | Qt::Key_Space] = shortcut;
+  hardCodedShortcuts_[Qt::Key_End] = shortcut; // already in GUI but will be forced if removed
   connect(shortcut, &QShortcut::activated, this, &MainWindow::on_actionLast_triggered);
   shortcut = new QShortcut(this);
   hardCodedShortcuts_[Qt::Key_Escape] = shortcut;
@@ -1120,6 +1120,13 @@ void MainWindow::setShortcuts(bool update) {
   }
 
   // set unambiguous hard-coded shortcuts too
+  // but force Home and End keys if they are not action shortcuts
+  if(hardCodedShortcuts.contains(Qt::Key_Home) && ui.actionFirst->shortcut() == QKeySequence(Qt::Key_Home)) {
+    hardCodedShortcuts.take(Qt::Key_Home)->setKey(QKeySequence());
+  }
+  if(hardCodedShortcuts.contains(Qt::Key_End) && ui.actionLast->shortcut() == QKeySequence(Qt::Key_End)) {
+    hardCodedShortcuts.take(Qt::Key_End)->setKey(QKeySequence());
+  }
   QMap<int, QShortcut*>::const_iterator it = hardCodedShortcuts.constBegin();
   while (it != hardCodedShortcuts.constEnd()) {
     it.value()->setKey(QKeySequence(it.key()));

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -29,6 +29,7 @@
 
 #include <QTableWidget>
 #include <QLabel>
+#include <QShortcut>
 
 #include <libfm-qt/foldermodel.h>
 #include <libfm-qt/proxyfoldermodel.h>
@@ -80,6 +81,8 @@ public:
     showFullScreen_ = value;
   }
 
+  void setShortcuts(bool update = false);
+
 protected:
   void loadImage(const Fm::FilePath & filePath, QModelIndex index = QModelIndex());
   void saveImage(const Fm::FilePath & filePath); // save current image to a file
@@ -97,6 +100,7 @@ protected:
   virtual bool eventFilter(QObject* watched, QEvent* event);
 private Q_SLOTS:
   void on_actionAbout_triggered();
+  void on_actionHiddenShortcuts_triggered();
 
   void on_actionOpenFile_triggered();
   void on_actionOpenDirectory_triggered();
@@ -197,6 +201,8 @@ private:
   QPointer<Fm::FileMenu> fileMenu_;
 
   bool showFullScreen_;
+
+  QMap<int, QShortcut*> hardCodedShortcuts_; // may be overriden by custom shortcuts
 };
 
 }

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -95,6 +95,7 @@
      <string>&amp;Help</string>
     </property>
     <addaction name="actionAbout"/>
+    <addaction name="actionHiddenShortcuts"/>
    </widget>
    <widget class="QMenu" name="menuGo">
     <property name="title">
@@ -209,6 +210,11 @@
    </property>
    <property name="text">
     <string>&amp;About</string>
+   </property>
+  </action>
+  <action name="actionHiddenShortcuts">
+   <property name="text">
+    <string>Hidden &amp;Shortcuts</string>
    </property>
   </action>
   <action name="actionOpenFile">

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -276,7 +276,7 @@ void PreferencesDialog::showWarning(const QString& text, bool temporary) {
           ui.warningLabel->setVisible(!permanentWarning_.isEmpty());
         });
       }
-      warningTimer_->start(2500);
+      warningTimer_->start(5000);
     }
   }
 }

--- a/src/shortcuts.ui
+++ b/src/shortcuts.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>These hard coded shortcuts will be overridden if they are also assigned in Preferences → Shortcuts.</string>
+      <string>These hard coded shortcuts will be overridden if they are also assigned to other actions in Preferences → Shortcuts.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -65,7 +65,7 @@
      </item>
      <item>
       <property name="text">
-       <string>Alt+Space</string>
+       <string>End</string>
       </property>
       <property name="text">
        <string>Last image</string>
@@ -89,7 +89,7 @@
      </item>
      <item>
       <property name="text">
-       <string>Alt+Backspace</string>
+       <string>Home</string>
       </property>
       <property name="text">
        <string>First image</string>

--- a/src/shortcuts.ui
+++ b/src/shortcuts.ui
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>HiddenShortcutsDialog</class>
+ <widget class="QDialog" name="HiddenShortcutsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Hidden Shortcuts</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>These hard coded shortcuts will be overridden if they are also assigned in Preferences → Shortcuts.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="margin">
+      <number>5</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTreeWidget" name="treeWidget">
+     <column>
+      <property name="text">
+       <string>Shortcut</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Action</string>
+      </property>
+     </column>
+     <item>
+      <property name="text">
+       <string>Esc</string>
+      </property>
+      <property name="text">
+       <string>Close window or exit fullscreen mode</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Right</string>
+      </property>
+      <property name="text">
+       <string>Next image</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Space</string>
+      </property>
+      <property name="text">
+       <string>Next image</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Alt+Space</string>
+      </property>
+      <property name="text">
+       <string>Last image</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Left</string>
+      </property>
+      <property name="text">
+       <string>Previous image</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Backspace</string>
+      </property>
+      <property name="text">
+       <string>Previous image</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Alt+Backspace</string>
+      </property>
+      <property name="text">
+       <string>First image</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>HiddenShortcutsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>HiddenShortcutsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
With this patch, hard-coded shortcuts (Escape → exiting/un-fullscreen, Space and Right → next image, Backspace and Left → previous image) can be overridden by custom shortcuts. Previously, overriding resulted in ambiguity, so that the shortcut was disabled.

Also, two hard-coded shortcuts and a "Hidden Shortcuts" dialog are added. The latter tells the user about overriding too.

In addition, the code is cleaned up with regard to custom shortcuts.

Fixes https://github.com/lxqt/lximage-qt/issues/475