### PR TITLE
Restore maximized state (if any) on un-fullscreening

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1177,11 +1177,8 @@ void MainWindow::on_actionPrint_triggered() {
 }
 
 // TODO: This can later be used for doing slide show
-void MainWindow::on_actionFullScreen_triggered(bool checked) {
-  if(checked)
-    showFullScreen();
-  else
-    showNormal();
+void MainWindow::on_actionFullScreen_triggered(bool /*checked*/) {
+  setWindowState(windowState() ^ Qt::WindowFullScreen);
 }
 
 void MainWindow::on_actionSlideShow_triggered(bool checked) {


### PR DESCRIPTION
The best method of fullscreening is check the maximized state before fullscreening and restore it on un-fullscreening. Previously, `showFullScreen()` was used; it removed the max state before fullscreening.