### PR TITLE
Fixed repainting of cached images

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -630,7 +630,7 @@ void ImageView::paintEvent(QPaintEvent* event) {
       if(cachedRect_.contains(repaintImageRect)) {
         QPainter painter(viewport());
         painter.fillRect(event->rect(), backgroundBrush());
-        painter.drawPixmap(repaintImageRect, cachedPixmap_);
+        painter.drawPixmap(cachedRect_, cachedPixmap_);
         // outline
         if(showOutline_) {
             QColor col = QColor(Qt::black);


### PR DESCRIPTION
Previously, the cached pixmap was drawn inside the repaint rectangle. That was wrong because there's no guarantee that the repaint rectangle is as big as the cached pixmap (e.g., it isn't so when the toolbar extension popup covers a part of the image and slides back). Therefore, visual glitches were imminent in special cases.

This patch draws the cached pixmap inside its corresponding cache rectangle, so that the image is always repainted correctly. The paint clipping is done by Qt automatically, as QPaintEvent's doc explains.

Fixes https://github.com/lxqt/lximage-qt/issues/557