### PR TITLE
Added Sorting sub-menu to View menu

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -149,6 +149,15 @@ private Q_SLOTS:
   void on_actionDrawCircle_triggered();
   void on_actionDrawNumber_triggered();
 
+  void on_actionByFileName_triggered(bool checked);
+  void on_actionByMTime_triggered(bool checked);
+  void on_actionByCrTime_triggered(bool checked);
+  void on_actionByFileSize_triggered(bool checked);
+  void on_actionByFileType_triggered(bool checked);
+
+  void onSortFilterChanged();
+  void sortMenuAboutToShow();
+
   void onContextMenu(QPoint pos);
   void onKeyboardEscape();
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -112,6 +112,16 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
+    <widget class="QMenu" name="menuSorting">
+     <property name="title">
+      <string>Sorting</string>
+     </property>
+     <addaction name="actionByFileName"/>
+     <addaction name="actionByMTime"/>
+     <addaction name="actionByCrTime"/>
+     <addaction name="actionByFileSize"/>
+     <addaction name="actionByFileType"/>
+    </widget>
     <addaction name="actionZoomIn"/>
     <addaction name="actionZoomOut"/>
     <addaction name="actionOriginalSize"/>
@@ -127,6 +137,8 @@
     <addaction name="actionMenubar"/>
     <addaction name="actionToolbar"/>
     <addaction name="actionAnnotations"/>
+    <addaction name="separator"/>
+    <addaction name="menuSorting"/>
    </widget>
    <widget class="QMenu" name="menu_Edit">
     <property name="title">
@@ -717,6 +729,61 @@
    </property>
    <property name="text">
     <string>Resize</string>
+   </property>
+  </action>
+  <action name="actionByFileName">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;By File Name</string>
+   </property>
+   <property name="toolTip">
+    <string>By File Name</string>
+   </property>
+  </action>
+  <action name="actionByMTime">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>By &amp;Modification Time</string>
+   </property>
+   <property name="toolTip">
+    <string>By Modification Time</string>
+   </property>
+  </action>
+  <action name="actionByCrTime">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>By C&amp;reation Time</string>
+   </property>
+   <property name="toolTip">
+    <string>By Creation Time</string>
+   </property>
+  </action>
+  <action name="actionByFileSize">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>By File &amp;Size</string>
+   </property>
+   <property name="toolTip">
+    <string>By File Size</string>
+   </property>
+  </action>
+  <action name="actionByFileType">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>By File &amp;Type</string>
+   </property>
+   <property name="toolTip">
+    <string>By File Type</string>
    </property>
   </action>
  </widget>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -25,6 +25,9 @@
 
 using namespace LxImage;
 
+inline static QString sortColumnToString(Fm::FolderModel::ColumnId value);
+inline static Fm::FolderModel::ColumnId sortColumnFromString(const QString& str);
+
 Settings::Settings():
   useFallbackIconTheme_(QIcon::themeName().isEmpty() || QIcon::themeName() == QLatin1String("hicolor")),
   bgColor_(255, 255, 255),
@@ -49,7 +52,8 @@ Settings::Settings():
   showAnnotationsToolbar_(false),
   forceZoomFit_(false),
   smoothOnZoom_(true),
-  useTrash_(true) {
+  useTrash_(true),
+  sorting_(Fm::FolderModel::ColumnFileName) {
 }
 
 Settings::~Settings() {
@@ -64,6 +68,7 @@ bool Settings::load() {
   slideShowInterval_ = settings.value(QStringLiteral("slideShowInterval"), slideShowInterval_).toInt();
   maxRecentFiles_ = settings.value(QStringLiteral("maxRecentFiles"), maxRecentFiles_).toInt();
   recentlyOpenedFiles_ = settings.value(QStringLiteral("recentlyOpenedFiles")).toStringList();
+  sorting_ = sortColumnFromString(settings.value(QStringLiteral("sorting")).toString());
 
   settings.beginGroup(QStringLiteral("Window"));
   fixedWindowWidth_ = settings.value(QStringLiteral("FixedWidth"), 640).toInt();
@@ -112,6 +117,7 @@ bool Settings::save() {
   settings.setValue(QStringLiteral("slideShowInterval"), slideShowInterval_);
   settings.setValue(QStringLiteral("maxRecentFiles"), maxRecentFiles_);
   settings.setValue(QStringLiteral("recentlyOpenedFiles"), recentlyOpenedFiles_);
+  settings.setValue(QStringLiteral("sorting"), sortColumnToString(sorting_));
 
   settings.beginGroup(QStringLiteral("Window"));
   settings.setValue(QStringLiteral("FixedWidth"), fixedWindowWidth_);
@@ -194,5 +200,51 @@ void Settings::thumbnailsPositionFromString(const QString& str) {
     return;
   }
   thumbnailsPosition_ = Qt::BottomDockWidgetArea;
+}
+
+static QString sortColumnToString(Fm::FolderModel::ColumnId value) {
+  QString ret;
+  switch(value) {
+  case Fm::FolderModel::ColumnFileName:
+  default:
+    ret = QLatin1String("name");
+    break;
+  case Fm::FolderModel::ColumnFileType:
+    ret = QLatin1String("type");
+    break;
+  case Fm::FolderModel::ColumnFileSize:
+    ret = QLatin1String("size");
+    break;
+  case Fm::FolderModel::ColumnFileMTime:
+    ret = QLatin1String("mtime");
+    break;
+  case Fm::FolderModel::ColumnFileCrTime:
+    ret = QLatin1String("crtime");
+    break;
+  }
+  return ret;
+}
+
+static Fm::FolderModel::ColumnId sortColumnFromString(const QString& str) {
+  Fm::FolderModel::ColumnId ret;
+  if(str == QLatin1String("name")) {
+    ret = Fm::FolderModel::ColumnFileName;
+  }
+  else if(str == QLatin1String("type")) {
+    ret = Fm::FolderModel::ColumnFileType;
+  }
+  else if(str == QLatin1String("size")) {
+    ret = Fm::FolderModel::ColumnFileSize;
+  }
+  else if(str == QLatin1String("mtime")) {
+    ret = Fm::FolderModel::ColumnFileMTime;
+  }
+  else if(str == QLatin1String("crtime")) {
+    ret = Fm::FolderModel::ColumnFileCrTime;
+  }
+  else {
+    ret = Fm::FolderModel::ColumnFileName;
+  }
+  return ret;
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -27,6 +27,7 @@
 #include <QColor>
 #include <QSize>
 #include <libfm-qt/core/thumbnailjob.h>
+#include <libfm-qt/foldermodel.h>
 
 namespace LxImage {
 
@@ -265,6 +266,13 @@ public:
     removedActions_ << action;
   }
 
+  Fm::FolderModel::ColumnId sorting() const {
+    return sorting_;
+  }
+  void setSorting(Fm::FolderModel::ColumnId sorting) {
+    sorting_ = sorting;
+  }
+
 private:
   QString thumbnailsPositionToString() const;
   void thumbnailsPositionFromString(const QString& str);
@@ -302,6 +310,8 @@ private:
 
   QHash<QString, QString> actions_;
   QStringList removedActions_;
+
+  Fm::FolderModel::ColumnId sorting_;
 };
 
 }


### PR DESCRIPTION
The app remembers sorting by name, file size, file type, modification time and creation time. Other kinds of sorting are ignored.

Closes https://github.com/lxqt/lximage-qt/issues/574