### PR TITLE
Remove image/tiff from lximage-qt.desktop

### DIFF
--- a/data/lximage-qt.desktop.in
+++ b/data/lximage-qt.desktop.in
@@ -5,4 +5,4 @@ Exec=lximage-qt %F
 StartupNotify=true
 Terminal=false
 Categories=Graphics;Viewer;RasterGraphics;2DGraphics;Photography;
-MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/png;image/tiff;image/x-bmp;image/x-pcx;image/x-tga;image/x-portable-pixmap;image/x-portable-bitmap;image/x-targa;image/x-portable-greymap;application/pcx;image/svg+xml;image/svg-xml;
+MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/png;image/x-bmp;image/x-pcx;image/x-tga;image/x-portable-pixmap;image/x-portable-bitmap;image/x-targa;image/x-portable-greymap;application/pcx;image/svg+xml;image/svg-xml;


### PR DESCRIPTION
LXImage-Qt can only open TIFF files if the qt5-imageformats module is installed.

Per the discussion at <https://github.com/lxqt/lximage-qt/issues/592#issuecomment-1374221733>, the .desktop file should only advertise support for formats that LXImage-Qt can open *without* installing the qt5-imageformats module.