### PR TITLE
Correct duplicate names for two QFormLayout in preferencesdialog.ui

### DIFF
--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -93,7 +93,7 @@
       <attribute name="title">
        <string>Window</string>
       </attribute>
-      <layout class="QFormLayout" name="formLayout_1">
+      <layout class="QFormLayout" name="formLayout_2">
        <property name="fieldGrowthPolicy">
         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
        </property>
@@ -141,7 +141,7 @@
       <attribute name="title">
        <string>Image</string>
       </attribute>
-      <layout class="QFormLayout" name="formLayout_2">
+      <layout class="QFormLayout" name="formLayout_3">
        <property name="fieldGrowthPolicy">
         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
        </property>


### PR DESCRIPTION
Corrects two QFormLayout with identical name "formLayout_1".

This suppresses compile time warning:
AutoUic: .../lximage-qt-git/src/lximage-qt/src/preferencesdialog.ui: Warning: The name 'formLayout_1' (QFormLayout) is already in use, defaulting to 'formLayout_11'.