### PR TITLE
Add 5 icons to the toolbar menus

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -409,6 +409,10 @@
    </property>
   </action>
   <action name="actionPrint">
+   <property name="icon">
+    <iconset theme="document-print">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Print</string>
    </property>
@@ -453,6 +457,10 @@
    </property>
   </action>
   <action name="actionFlipHorizontal">
+   <property name="icon">
+    <iconset theme="object-flip-horizontal">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Flip &amp;Horizontally</string>
    </property>
@@ -481,6 +489,10 @@
    </property>
   </action>
   <action name="actionFlipVertical">
+   <property name="icon">
+    <iconset theme="object-flip-vertical">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Flip &amp;Vertically</string>
    </property>
@@ -533,6 +545,10 @@
    </property>
   </action>
   <action name="actionFileProperties">
+   <property name="icon">
+    <iconset theme="document-properties">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>File Properties</string>
    </property>

--- a/src/mrumenu.cpp
+++ b/src/mrumenu.cpp
@@ -46,7 +46,7 @@ MruMenu::MruMenu(QWidget *parent)
     mSeparator->setVisible(!mFilenames.empty());
 
     // Add the clear action and disable it if there are no items in the list
-    mClearAction = new QAction(tr("&Clear"));
+    mClearAction = new QAction(QIcon::fromTheme(QStringLiteral("edit-clear")), tr("&Clear"));
     mClearAction->setEnabled(!mFilenames.empty());
     connect(mClearAction, &QAction::triggered, this, &MruMenu::onClearTriggered);
     addAction(mClearAction);


### PR DESCRIPTION
5 menu icons added to LXImage-Qt's toolbar: namely 'document-print', 'object-flip-horizontal', 'object-flip-vertical', 'document-properties', and 'edit-clear'.

The icons exist in well-known icon sets; the Adwaita icon set has them but in "-symbolic" form.