### PR TITLE
Fixed a crash on using annotations with Qt ≥ 6.7

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -678,8 +678,11 @@ void ImageView::queueGenerateCache() {
 // really generate the cache
 void ImageView::generateCache() {
   // disable the one-shot timer
-  cacheTimer_->deleteLater();
-  cacheTimer_ = nullptr;
+  if(cacheTimer_) {
+    cacheTimer_->stop();
+    delete cacheTimer_;
+    cacheTimer_ = nullptr;
+  }
 
   if(!imageItem_ || image_.isNull()
      || scaleFactor_ == 1.0 || gifMovie_ || isSVG || !smoothOnZoom_) {


### PR DESCRIPTION
This is similar to https://github.com/lxqt/lxqt-notificationd/pull/375. Both fixes are logical, regardless of what has changed in Qt 6.7.