### PR TITLE
Remove useless translation

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -278,7 +278,7 @@ void MainWindow::on_actionAbout_triggered() {
                      QStringLiteral("<center><b><big>LXImage-Qt %1</big></b></center><br>").arg(qApp->applicationVersion())
                      + tr("A simple and fast image viewer")
                      + QStringLiteral("<br><br>")
-                     + tr("Copyright (C) ") + tr("2013-2023")
+                     + tr("Copyright (C) ") + QStringLiteral("2013-2024")
                      + QStringLiteral("<br><a href='https://lxqt-project.org'>")
                      + tr("LXQt Project")
                      + QStringLiteral("</a><br><br>")


### PR DESCRIPTION
Stumbled upon that while updating translations - existing translations are often outdated if not wrong:
```
$   <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>Kattaa vuodet 2013-2022</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013. – 2021.</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation type="unfinished">2013–2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>
        <translation>2013-2021</translation>

```