### PR TITLE
Small fix to screenshot select area

### DIFF
--- a/src/screenshotselectarea.cpp
+++ b/src/screenshotselectarea.cpp
@@ -29,9 +29,10 @@ ScreenshotSelectArea::ScreenshotSelectArea(const QImage & image, QWidget* parent
   scene_->addPixmap(QPixmap::fromImage(image));
 
   view_ = new ScreenshotSelectAreaGraphicsView(scene_, this);
-  view_->setRenderHints( QPainter::Antialiasing );
-  view_->setHorizontalScrollBarPolicy ( Qt::ScrollBarAlwaysOff );
-  view_->setVerticalScrollBarPolicy ( Qt::ScrollBarAlwaysOff );
+  view_->setRenderHints(QPainter::Antialiasing);
+  view_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  view_->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  view_->setFrameStyle(QFrame::NoFrame);
   view_->show();
   view_->move(0,0);
   view_->resize(image.width(), image.height());


### PR DESCRIPTION
Set QFrame::NoFrame on ScreenshotSelectAreaGraphicsView to prevent the main view from being oversized. Previously it's possible to use the arrow keys to shift the view 1px.

Additionally, another change should be made for allowing to select the entire screen area (it's off my 1px regardless of this.)