### PR TITLE
Cleanup licenses

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,7 +3,7 @@ Upstream Authors:
     Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
 
 Copyright:
-    Copyright (c) 2013-2020 LXQt team
+    Copyright (c) 2013-2024 LXQt team
 
-License: GPL-2+ and LGPL-2.1+
+License: GPL-2+
 The full text of the licenses can be found in the 'COPYING' file.

--- a/data/lximage-qt.metainfo.xml
+++ b/data/lximage-qt.metainfo.xml
@@ -9,7 +9,7 @@
   <summary>Fast image viewer</summary>
 
   <metadata_license>CC-BY-4.0</metadata_license>
-  <project_license>GPL-2.0-only</project_license>
+  <project_license>GPL-2.0-or-later</project_license>
 
   <description>
     <p>


### PR DESCRIPTION
Fixes https://github.com/lxqt/lximage-qt/issues/645

All files in /src have the header below, I don't see any need for adding  LGPL-2.1+ anywhere.
```
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or
 * (at your option) any later version.
 ```