### PR TITLE
Don't set a limit for image size

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -43,6 +43,9 @@ bool Application::init(int argc, char** argv) {
   Q_UNUSED(argc)
   Q_UNUSED(argv)
 
+  // no reason to set an allocation limit because this is an image viewer
+  QImageReader::setAllocationLimit(0);
+
   // install the translations built-into Qt itself
   if(qtTranslator.load(QStringLiteral("qt_") + QLocale::system().name(), QLibraryInfo::path(QLibraryInfo::TranslationsPath))) {
       installTranslator(&qtTranslator);


### PR DESCRIPTION
Qt6 started to set an allocation limit of 256 MiB. The behavior of Qt5 is restored here, i.e., no limit is set, because this is an image viewer.

Closes https://github.com/lxqt/lximage-qt/issues/690