### PR TITLE
Fixed invalid nullptr parameter in `QObject::connect`

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -94,11 +94,11 @@ protected:
   virtual void resizeEvent(QResizeEvent *event);
   virtual void closeEvent(QCloseEvent *event);
 
+  virtual bool eventFilter(QObject* watched, QEvent* event);
+private Q_SLOTS:
   void onImageLoaded();
   void onImageSaved();
 
-  virtual bool eventFilter(QObject* watched, QEvent* event);
-private Q_SLOTS:
   void on_actionMenubar_triggered(bool checked);
   void on_actionAbout_triggered();
   void on_actionHiddenShortcuts_triggered();

--- a/src/upload/imgbbprovider.cpp
+++ b/src/upload/imgbbprovider.cpp
@@ -29,8 +29,13 @@ using namespace LxImage;
 
 const QUrl gUploadURL(QStringLiteral("https://imgbb.com/json"));
 
+ImgBBProvider::ImgBBProvider(QObject *parent) : Provider(parent) {}
+
 Upload *ImgBBProvider::upload(QIODevice *device)
 {
+    if(!sManager) {
+        return nullptr;
+    }
     // Create the file part of the multipart request
     QHttpPart filePart;
     filePart.setBodyDevice(device);
@@ -60,5 +65,5 @@ Upload *ImgBBProvider::upload(QIODevice *device)
     multiPart->append(filePart);
 
     // Start the request and wrap it in an ImgBBUpload
-    return new ImgBBUpload(sManager.post(QNetworkRequest(gUploadURL), multiPart));
+    return new ImgBBUpload(sManager->post(QNetworkRequest(gUploadURL), multiPart));
 }

--- a/src/upload/imgbbprovider.h
+++ b/src/upload/imgbbprovider.h
@@ -29,6 +29,7 @@ class ImgBBProvider : public Provider
     Q_OBJECT
 
 public:
+    ImgBBProvider(QObject *parent = nullptr);
 
     virtual Upload *upload(QIODevice *device);
 };

--- a/src/upload/imgurprovider.cpp
+++ b/src/upload/imgurprovider.cpp
@@ -31,13 +31,18 @@ const QUrl gUploadURL(QStringLiteral("https://api.imgur.com/3/upload.json"));
 const QByteArray gAuthHeader = "Client-ID 63ff047cd8bcf9e";
 const QByteArray gTypeHeader = "application/x-www-form-urlencoded";
 
+ImgurProvider::ImgurProvider(QObject *parent) : Provider(parent) {}
+
 Upload *ImgurProvider::upload(QIODevice *device)
 {
+    if(!sManager) {
+        return nullptr;
+    }
     // Create the request with the correct HTTP headers
     QNetworkRequest request(gUploadURL);
     request.setHeader(QNetworkRequest::ContentTypeHeader, gTypeHeader);
     request.setRawHeader("Authorization", gAuthHeader);
 
     // Start the request and wrap it in an ImgurUpload
-    return new ImgurUpload(sManager.post(request, device));
+    return new ImgurUpload(sManager->post(request, device));
 }

--- a/src/upload/imgurprovider.h
+++ b/src/upload/imgurprovider.h
@@ -33,6 +33,7 @@ class ImgurProvider : public Provider
     Q_OBJECT
 
 public:
+    ImgurProvider(QObject *parent = nullptr);
 
     virtual Upload *upload(QIODevice *device);
 };

--- a/src/upload/provider.cpp
+++ b/src/upload/provider.cpp
@@ -22,4 +22,19 @@
 
 using namespace LxImage;
 
-QNetworkAccessManager Provider::sManager;
+QPointer<QNetworkAccessManager> Provider::sManager;
+int Provider::ref(0);
+
+Provider::Provider(QObject *parent) : QObject(parent) {
+    ++ref;
+    if(!sManager) {
+        sManager = new QNetworkAccessManager;
+    }
+}
+
+Provider::~Provider() {
+    --ref;
+    if(ref == 0) {
+        delete sManager;
+    }
+}

--- a/src/upload/provider.h
+++ b/src/upload/provider.h
@@ -24,6 +24,7 @@
 #include <QIODevice>
 #include <QNetworkAccessManager>
 #include <QObject>
+#include <QPointer>
 
 namespace LxImage {
 
@@ -37,6 +38,8 @@ class Provider : public QObject
     Q_OBJECT
 
 public:
+    Provider(QObject *parent = nullptr);
+    ~Provider();
 
     /**
      * @brief Upload the provided data
@@ -46,8 +49,10 @@ public:
     virtual Upload *upload(QIODevice *device) = 0;
 
 protected:
+    static QPointer<QNetworkAccessManager> sManager;
 
-    static QNetworkAccessManager sManager;
+private:
+    static int ref;
 };
 
 }

--- a/src/upload/uploaddialog.cpp
+++ b/src/upload/uploaddialog.cpp
@@ -27,16 +27,11 @@
 #include <QPushButton>
 #include <QVariant>
 
-#include "imgbbprovider.h"
-#include "imgurprovider.h"
 #include "provider.h"
 #include "upload.h"
 #include "uploaddialog.h"
 
 using namespace LxImage;
-
-ImgurProvider gImgurProvider;
-ImgBBProvider gImgBBProvider;
 
 UploadDialog::UploadDialog(QWidget *parent, const QString &filename)
     : QDialog(parent),
@@ -47,8 +42,10 @@ UploadDialog::UploadDialog(QWidget *parent, const QString &filename)
     ui.setupUi(this);
 
     // Populate the list of providers
-    ui.providerComboBox->addItem(tr("Imgur"), QVariant::fromValue(&gImgurProvider));
-    ui.providerComboBox->addItem(tr("ImgBB"), QVariant::fromValue(&gImgBBProvider));
+    mImgurProvider = new ImgurProvider(this);
+    mImgBBProvider = new ImgBBProvider(this);
+    ui.providerComboBox->addItem(tr("Imgur"), QVariant::fromValue(mImgurProvider));
+    ui.providerComboBox->addItem(tr("ImgBB"), QVariant::fromValue(mImgBBProvider));
 
     updateUi();
 }
@@ -60,7 +57,9 @@ void UploadDialog::on_actionButton_clicked()
         start();
         break;
     case UploadInProgress:
-        mUpload->abort();
+        if(mUpload) {
+            mUpload->abort();
+        }
         break;
     case Completed:
         accept();
@@ -88,6 +87,9 @@ void UploadDialog::start()
 
     // Create the upload
     mUpload = provider->upload(&mFile);
+    if(!mUpload) {
+        return;
+    }
 
     // Update the progress bar as the upload progresses
     connect(mUpload, &Upload::progress, ui.progressBar, &QProgressBar::setValue);

--- a/src/upload/uploaddialog.h
+++ b/src/upload/uploaddialog.h
@@ -25,6 +25,8 @@
 #include <QFile>
 
 #include "ui_uploaddialog.h"
+#include "imgbbprovider.h"
+#include "imgurprovider.h"
 
 namespace LxImage {
 
@@ -68,6 +70,9 @@ private:
     QFile mFile;
 
     Upload *mUpload;
+
+    ImgurProvider *mImgurProvider;
+    ImgBBProvider *mImgBBProvider;
 };
 
 }


### PR DESCRIPTION
`QNetworkAccessManager` is changed to a static `QPointer`, which is deleted when all instances of `Provider` are deleted.

In addition, all providers are created on the heap, as children of the upload dialog.

In this way, the following warning is silenced:

```
qt.core.qobject.connect: QObject::connect(QObject, Unknown): invalid nullptr parameter
```