### PR TITLE
Use the device pixel ratio of the window on Wayland

### DIFF
--- a/src/imageview.h
+++ b/src/imageview.h
@@ -123,6 +123,8 @@ private:
 
   void resetView();
 
+  qreal getPixelRatio() const;
+
 private Q_SLOTS:
   void onFileDropped(const QString file);
   void generateCache();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -235,6 +235,13 @@ MainWindow::MainWindow():
 
   // set custom and hard-coded shortcuts
   setShortcuts();
+
+  if(QGuiApplication::platformName() == QStringLiteral("wayland")) {
+    // On Wayland, we should set the pixel ratio of the image by consulting
+    // the window handle when the image is shown at the startup, because each
+    // screen can have its own scaling. Hence the early creation of the handle.
+    winId();
+  }
 }
 
 MainWindow::~MainWindow() {
@@ -882,7 +889,15 @@ void MainWindow::updateUI() {
           show();
           int scrollThickness = style()->pixelMetric(QStyle::PM_ScrollBarExtent);
           QSize newSize = size() + image_.size() - ui.view->size() + QSize(scrollThickness, scrollThickness);
-          QScreen *appScreen = QGuiApplication::screenAt(QCursor::pos());
+          QScreen *appScreen = nullptr;
+          if(QGuiApplication::platformName() == QStringLiteral("wayland")) {
+            if(QWindow *win = windowHandle()) {
+              appScreen = win->screen();
+            }
+          }
+          else {
+            appScreen = QGuiApplication::screenAt(QCursor::pos());
+          }
           if(appScreen == nullptr) {
             appScreen = QGuiApplication::primaryScreen();
           }


### PR DESCRIPTION
On Wayland, each screen can have its own device pixel ratio, which is correctly reported by the window, not by the app.

The app's behavior under X11 is like before.

Closes https://github.com/lxqt/lximage-qt/issues/701