### PR TITLE
Fixes and workarounds for multi-screen scaling issues on Wayland

### DIFF
--- a/src/imageview.h
+++ b/src/imageview.h
@@ -41,7 +41,7 @@ public:
   ImageView(QWidget* parent = nullptr);
   virtual ~ImageView();
 
-  void setImage(const QImage& image, bool show = true);
+  void setImage(const QImage& image, bool show = true, bool updatePixelRatio = true);
   void setGifAnimation(const QString& fileName);
   void setSVG(const QString& fileName);
 
@@ -144,12 +144,13 @@ private:
   double scaleFactor_;
   bool autoZoomFit_;
   bool smoothOnZoom_;
-  bool isSVG; // is the image an SVG file?
+  bool isSVG_; // is the image an SVG file?
   Tool currentTool_; // currently selected tool
   QPoint startPoint_; // starting point for the tool
   QList<QGraphicsItem *> annotations_; //annotation items which have been drawn in the scene
   int nextNumber_;
   bool showOutline_;
+  qreal pixRatio_;
 };
 
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -186,8 +186,6 @@ private:
   // FmFileInfo* currentFileInfo_; // info of the current file, can be NULL
   bool imageModified_; // the current image is modified by rotation, flip, or others and needs to be saved
 
-  bool startMaximized_;
-
   // folder browsing
   std::shared_ptr<Fm::Folder> folder_;
   Fm::FilePath folderPath_;
@@ -213,6 +211,8 @@ private:
   bool showFullScreen_;
 
   QMap<int, QShortcut*> hardCodedShortcuts_; // may be overridden by custom shortcuts
+
+  qreal lastPixRatio_;
 };
 
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -41,6 +41,7 @@ Settings::Settings():
   slideShowInterval_(5),
   fallbackIconTheme_(QStringLiteral("oxygen")),
   maxRecentFiles_(5),
+  rememberWindowSize_(true),
   fixedWindowWidth_(640),
   fixedWindowHeight_(480),
   lastWindowWidth_(640),
@@ -77,7 +78,7 @@ bool Settings::load() {
   lastWindowWidth_ = settings.value(QStringLiteral("LastWindowWidth"), 640).toInt();
   lastWindowHeight_ = settings.value(QStringLiteral("LastWindowHeight"), 480).toInt();
   lastWindowMaximized_ = settings.value(QStringLiteral("LastWindowMaximized"), false).toBool();
-  rememberWindowSize_ = settings.value(QStringLiteral("RememberWindowSize"), true).toBool();
+  //rememberWindowSize_ = settings.value(QStringLiteral("RememberWindowSize"), true).toBool();
   showOutline_ = settings.value(QStringLiteral("ShowOutline"), false).toBool();
   showExifData_ = settings.value(QStringLiteral("ShowExifData"), false).toBool();
   exifDatakWidth_ = settings.value(QStringLiteral("ExifDatakWidth"), 250).toInt();
@@ -127,7 +128,7 @@ bool Settings::save() {
   settings.setValue(QStringLiteral("LastWindowWidth"), lastWindowWidth_);
   settings.setValue(QStringLiteral("LastWindowHeight"), lastWindowHeight_);
   settings.setValue(QStringLiteral("LastWindowMaximized"), lastWindowMaximized_);
-  settings.setValue(QStringLiteral("RememberWindowSize"), rememberWindowSize_);
+  //settings.setValue(QStringLiteral("RememberWindowSize"), rememberWindowSize_);
   settings.setValue(QStringLiteral("ShowOutline"), showOutline_);
   settings.setValue(QStringLiteral("ShowMenubar"), showMenubar_);
   settings.setValue(QStringLiteral("ShowToolbar"), showToolbar_);


### PR DESCRIPTION
The issues were bizarre — especially in one case, all relevant Qt methods gave wrong pixel ratios — but workarounds were effective.

Also,
 * Fixed an old issue in showing GIF animations with pixel ratios > 1;
 * Commented out "RememberWindowSize" from settings because it was never used (but might be used later); and
 * Removed a redundant private variable.

Closes https://github.com/lxqt/lximage-qt/issues/703