### PR TITLE
Add document-open-recent icon to "Recently Opened Files"

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -71,6 +71,10 @@
      <property name="title">
       <string>&amp;Recently Opened Files</string>
      </property>
+     <property name="icon">
+      <iconset theme="document-open-recent">
+       <normaloff>.</normaloff>.</iconset>
+     </property>
     </widget>
     <addaction name="actionNewWindow"/>
     <addaction name="actionOpenFile"/>


### PR DESCRIPTION
See PCManFM-Qt's usage

Also "Recently Opened Files" is a bit verbose - replace with "Recent Files"? Regardless, I did not want to change translations.