### PR TITLE
Silenced compilation warning about `QImage::mirrored`

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -360,12 +360,16 @@ void ImageView::flipImage(bool horizontal) {
     }
   }
   if(!image_.isNull()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6,9,0))
+    image_ = image_.flipped(horizontal ? Qt::Horizontal : Qt::Vertical);
+#else
     if(horizontal) {
       image_ = image_.mirrored(true, false);
     }
     else {
       image_ = image_.mirrored(false, true);
     }
+#endif
     int tmp = nextNumber_;
     setImage(image_, !gifMovie_ && !isSVG_, false);
     nextNumber_ = tmp;


### PR DESCRIPTION
Since Qt 6.9, image flipping is done by `QImage::flipped`. A version check is added.