### PR TITLE
Supported multi-page TIFF images

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -506,7 +506,26 @@ void ImageView::setImage(const QImage& image, bool show, bool updatePixelRatio) 
   queueGenerateCache();
 }
 
-void ImageView::setGifAnimation(const QString& fileName) {
+bool ImageView::supportsAnimation(const QString& fileName) const {
+  QMovie movie(fileName);
+  return movie.frameCount() > 1;
+}
+
+void ImageView::nextFrame() {
+  if(gifMovie_ && gifMovie_->frameCount() > 1) {
+    int curFrame = gifMovie_->currentFrameNumber();
+    gifMovie_->jumpToFrame(curFrame < gifMovie_->frameCount() - 1 ? curFrame + 1 : 0);
+  }
+}
+
+void ImageView::previousFrame() {
+  if(gifMovie_ && gifMovie_->frameCount() > 1) {
+    int curFrame = gifMovie_->currentFrameNumber();
+    gifMovie_->jumpToFrame(curFrame > 0 ? curFrame - 1 : gifMovie_->frameCount() - 1);
+  }
+}
+
+void ImageView::setGifAnimation(const QString& fileName, bool startAnimation) {
   resetView();
   /* the built-in gif reader gives the first frame, which won't
      be shown but is used for tracking position and dimensions */
@@ -544,7 +563,12 @@ void ImageView::setGifAnimation(const QString& fileName) {
     gifLabel->setAttribute(Qt::WA_NoSystemBackground);
     gifLabel->setMovie(gifMovie_);
     gifWidget->setWidget(gifLabel);
-    gifMovie_->start();
+    if(startAnimation) {
+      gifMovie_->start();
+    }
+    else {
+      gifMovie_->jumpToFrame(0);
+    }
     scene_->addItem(gifItem);
     scene_->setSceneRect(gifItem->boundingRect());
 

--- a/src/imageview.h
+++ b/src/imageview.h
@@ -42,7 +42,7 @@ public:
   virtual ~ImageView();
 
   void setImage(const QImage& image, bool show = true, bool updatePixelRatio = true);
-  void setGifAnimation(const QString& fileName);
+  void setGifAnimation(const QString& fileName, bool startAnimation);
   void setSVG(const QString& fileName);
 
   QImage image() const {
@@ -80,6 +80,11 @@ public:
 
   // if set to true, hides the cursor after 3s of inactivity
   void hideCursor(bool enable);
+
+  // for multi-page TIFF images
+  bool supportsAnimation(const QString& fileName) const;
+  void nextFrame();
+  void previousFrame();
 
   // Annotation tools
   enum Tool {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -136,6 +136,9 @@ private Q_SLOTS:
   void on_actionFirst_triggered();
   void on_actionLast_triggered();
 
+  void on_actionNextFrame_triggered();
+  void on_actionPreviousFrame_triggered();
+
   void on_actionZoomIn_triggered();
   void on_actionZoomOut_triggered();
   void on_actionOriginalSize_triggered();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -111,6 +111,9 @@
     <addaction name="actionNext"/>
     <addaction name="actionFirst"/>
     <addaction name="actionLast"/>
+    <addaction name="separator"/>
+    <addaction name="actionNextFrame"/>
+    <addaction name="actionPreviousFrame"/>
    </widget>
    <widget class="QMenu" name="menu_View">
     <property name="title">
@@ -804,6 +807,22 @@
    </property>
    <property name="toolTip">
     <string>By File Type</string>
+   </property>
+  </action>
+  <action name="actionNextFrame">
+   <property name="text">
+    <string>Next Frame</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Right</string>
+   </property>
+  </action>
+  <action name="actionPreviousFrame">
+   <property name="text">
+    <string>Previous Frame</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Left</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
If a multi-page TIFF image is opened, the menu-items "Next Frame" and "Previous Frame" will be added to the "Go" menu, with the shortcuts "Ctrl+Right" and "Ctrl+Left" respectively. Of course the shortcuts can be changed in the shortcut editor.

To prevent cluttering of the GUI for this special use case, I didn't add another way of informing the users. They should either check the "Go" menu or press those shortcuts to see whether a TIFF image includes multiple pages.

Closes https://github.com/lxqt/lximage-qt/issues/721