### PR TITLE
More complete support for multi-page TIFF images

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -511,17 +511,63 @@ bool ImageView::supportsAnimation(const QString& fileName) const {
   return movie.frameCount() > 1;
 }
 
+int ImageView::frameCount() const {
+  if(gifMovie_) {
+    return gifMovie_->frameCount();
+  }
+  return 0;
+}
+
+int ImageView::currentFrame() const {
+  if(gifMovie_) {
+    return gifMovie_->currentFrameNumber() + 1;
+  }
+  return 0;
+}
+
 void ImageView::nextFrame() {
   if(gifMovie_ && gifMovie_->frameCount() > 1) {
+    removeAnnotations();
     int curFrame = gifMovie_->currentFrameNumber();
     gifMovie_->jumpToFrame(curFrame < gifMovie_->frameCount() - 1 ? curFrame + 1 : 0);
+    image_ = gifMovie_->currentImage();
+    if(QGraphicsItem* imageItem = imageGraphicsItem()) {
+        image_ = image_.transformed(imageItem->transform(), Qt::SmoothTransformation);
+    }
   }
 }
 
 void ImageView::previousFrame() {
   if(gifMovie_ && gifMovie_->frameCount() > 1) {
+    removeAnnotations();
     int curFrame = gifMovie_->currentFrameNumber();
     gifMovie_->jumpToFrame(curFrame > 0 ? curFrame - 1 : gifMovie_->frameCount() - 1);
+    image_ = gifMovie_->currentImage();
+    if(QGraphicsItem* imageItem = imageGraphicsItem()) {
+        image_ = image_.transformed(imageItem->transform(), Qt::SmoothTransformation);
+    }
+  }
+}
+
+void ImageView::firstFrame() {
+  if(gifMovie_ && gifMovie_->currentFrameNumber() > 0) {
+    removeAnnotations();
+    gifMovie_->jumpToFrame(0);
+    image_ = gifMovie_->currentImage();
+    if(QGraphicsItem* imageItem = imageGraphicsItem()) {
+        image_ = image_.transformed(imageItem->transform(), Qt::SmoothTransformation);
+    }
+  }
+}
+
+void ImageView::lastFrame() {
+  if(gifMovie_ && gifMovie_->currentFrameNumber() < gifMovie_->frameCount() - 1) {
+    removeAnnotations();
+    gifMovie_->jumpToFrame(gifMovie_->frameCount() - 1);
+    image_ = gifMovie_->currentImage();
+    if(QGraphicsItem* imageItem = imageGraphicsItem()) {
+        image_ = image_.transformed(imageItem->transform(), Qt::SmoothTransformation);
+    }
   }
 }
 
@@ -850,6 +896,10 @@ void ImageView::resetView() {
     }
   }
   // remove annotations
+  removeAnnotations();
+}
+
+void ImageView::removeAnnotations() {
   if(!annotations_.isEmpty()) {
     if(!scene_->items().isEmpty()) { // WARNING: This is not enough to guard against dangling pointers.
       for(const auto& annotation : std::as_const(annotations_)) {

--- a/src/imageview.h
+++ b/src/imageview.h
@@ -83,8 +83,12 @@ public:
 
   // for multi-page TIFF images
   bool supportsAnimation(const QString& fileName) const;
+  int frameCount() const;
+  int currentFrame() const; // starts with 1, not 0
   void nextFrame();
   void previousFrame();
+  void firstFrame();
+  void lastFrame();
 
   // Annotation tools
   enum Tool {
@@ -127,6 +131,7 @@ private:
                  int tipLen);
 
   void resetView();
+  void removeAnnotations();
 
   qreal getPixelRatio() const;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -138,6 +138,8 @@ private Q_SLOTS:
 
   void on_actionNextFrame_triggered();
   void on_actionPreviousFrame_triggered();
+  void on_actionFirstFrame_triggered();
+  void on_actionLastFrame_triggered();
 
   void on_actionZoomIn_triggered();
   void on_actionZoomOut_triggered();
@@ -175,7 +177,7 @@ private Q_SLOTS:
 
 private:
   void onFolderLoaded();
-  void updateUI();
+  void updateUI(bool multiFrame = false);
   void setModified(bool modified);
   QModelIndex indexFromPath(const Fm::FilePath & filePath);
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -112,8 +112,10 @@
     <addaction name="actionFirst"/>
     <addaction name="actionLast"/>
     <addaction name="separator"/>
-    <addaction name="actionNextFrame"/>
     <addaction name="actionPreviousFrame"/>
+    <addaction name="actionNextFrame"/>
+    <addaction name="actionFirstFrame"/>
+    <addaction name="actionLastFrame"/>
    </widget>
    <widget class="QMenu" name="menu_View">
     <property name="title">
@@ -823,6 +825,16 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Left</string>
+   </property>
+  </action>
+  <action name="actionFirstFrame">
+   <property name="text">
+    <string>First Frame</string>
+   </property>
+  </action>
+  <action name="actionLastFrame">
+   <property name="text">
+    <string>Last Frame</string>
    </property>
   </action>
  </widget>

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -78,6 +78,11 @@ StatusBar::StatusBar(QWidget* parent)
   pathLabel_->hide();
   pathLabel_->setFrameShape(QFrame::NoFrame);
   addWidget(pathLabel_);
+
+  permanentLabel_ = new QLabel();
+  permanentLabel_->setIndent(2);
+  addPermanentWidget(permanentLabel_);
+  permanentLabel_->hide();
 }
 
 StatusBar::~StatusBar() {
@@ -91,6 +96,17 @@ void StatusBar::setText(const QString& sizeTxt, const QString& pathTxt) {
   pathLabel_->setText(pathTxt);
   pathLabel0_->setVisible(!pathTxt.isEmpty());
   pathLabel_->setVisible(!pathTxt.isEmpty());
+
+  // also hide the permanent label when there is no size and path text
+  if(sizeTxt.isEmpty() && pathTxt.isEmpty()) {
+    permanentLabel_->clear();
+    permanentLabel_->setVisible(false);
+  }
+}
+
+void StatusBar::setPermanentText(const QString& text) {
+  permanentLabel_->setText(text);
+  permanentLabel_->setVisible(!text.isEmpty());
 }
 
 }

--- a/src/statusbar.h
+++ b/src/statusbar.h
@@ -51,9 +51,13 @@ public:
   ~StatusBar();
 
   void setText(const QString& sizeTxt = QString(), const QString& pathTxt = QString());
+  void setPermanentText(const QString& text = QString());
+  bool hasPermanentText() const {
+    return permanentLabel_ != nullptr && permanentLabel_->isVisible();
+  }
 
 private:
-  QLabel *sizeLabel0_, *sizeLabel_, *pathLabel0_;
+  QLabel *sizeLabel0_, *sizeLabel_, *pathLabel0_, *permanentLabel_;
   Label *pathLabel_; // an elided path
 };
 


### PR DESCRIPTION
The changes:

 1. Two extra actions are added for going to the first and last frames.
 2. A label appears on the right side of the status-bar, which shows the current frame and the total number of frames.
 3. On saving, the current frame is saved, with all applied transformations.
 4. On copying to clipboard, the current frame is copied, with all applied transformations.
 5. The annotations are cleared on changing the frame. The reason is twofold: first, this is consistent with changing the viewed image; second, the annotations could be saved only if they are applied to the current frame.