### PR TITLE
Support non-solid (tiled) background

### DIFF
--- a/src/imageview.h
+++ b/src/imageview.h
@@ -100,7 +100,7 @@ public:
   };
   void activateTool(Tool tool);
   void showOutline(bool show);
-  void updateOutline();
+  void setViewBackground(const QBrush& brush, bool solidBg);
 
 Q_SIGNALS:
   void fileDropped(const QString file);
@@ -115,6 +115,7 @@ protected:
   virtual void focusInEvent(QFocusEvent* event);
   virtual void resizeEvent(QResizeEvent* event);
   virtual void paintEvent(QPaintEvent* event);
+  virtual void drawBackground(QPainter *p, const QRectF& rect);
 
 private:
   QGraphicsItem* imageGraphicsItem() const;
@@ -161,6 +162,7 @@ private:
   int nextNumber_;
   bool showOutline_;
   qreal pixRatio_;
+  bool tiledBg_;
 };
 
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -109,9 +109,8 @@ MainWindow::MainWindow():
   // install an event filter on the image view
   ui.view->installEventFilter(this);
 
-  ui.view->setBackgroundBrush(QBrush(settings.bgColor()));
-
-  ui.view->updateOutline();
+  ui.view->setViewBackground(QBrush(settings.bgColor()), settings.solidBg());
+  ui.actionSolidBg->setChecked(settings.solidBg());
 
   ui.view->showOutline(settings.isOutlineShown());
   ui.actionShowOutline->setChecked(settings.isOutlineShown());
@@ -174,6 +173,7 @@ MainWindow::MainWindow():
   contextMenu_->addSeparator();
   contextMenu_->addAction(ui.actionSlideShow);
   contextMenu_->addAction(ui.actionFullScreen);
+  contextMenu_->addAction(ui.actionSolidBg);
   contextMenu_->addAction(ui.actionShowOutline);
   contextMenu_->addAction(ui.actionShowExifData);
   contextMenu_->addAction(ui.actionShowThumbnails);
@@ -1214,11 +1214,9 @@ void MainWindow::setModified(bool modified) {
 void MainWindow::applySettings() {
   Application* app = static_cast<Application*>(qApp);
   Settings& settings = app->settings();
-  if(isFullScreen())
-    ui.view->setBackgroundBrush(QBrush(settings.fullScreenBgColor()));
-  else
-    ui.view->setBackgroundBrush(QBrush(settings.bgColor()));
-  ui.view->updateOutline();
+  ui.view->setViewBackground(isFullScreen() ? QBrush(settings.fullScreenBgColor())
+                                            : QBrush(settings.bgColor()),
+                             ui.actionSolidBg->isChecked());
   ui.view->setSmoothOnZoom(settings.smoothOnZoom());
   ui.menuRecently_Opened_Files->setMaxItems(settings.maxRecentFiles());
 
@@ -1360,6 +1358,13 @@ void MainWindow::on_actionSlideShow_triggered(bool checked) {
 
 void MainWindow::on_actionShowThumbnails_triggered(bool checked) {
   setShowThumbnails(checked);
+}
+
+void MainWindow::on_actionSolidBg_triggered(bool checked) {
+  Settings& settings = static_cast<Application*>(qApp)->settings();
+  ui.view->setViewBackground(isFullScreen() ? QBrush(settings.fullScreenBgColor())
+                                            : QBrush(settings.bgColor()),
+                             checked);
 }
 
 void MainWindow::on_actionShowOutline_triggered(bool checked) {
@@ -1523,8 +1528,7 @@ void MainWindow::changeEvent(QEvent* event) {
     Settings& settings = static_cast<Application*>(qApp)->settings();
     if(isFullScreen()) { // changed to fullscreen mode
       ui.view->setFrameStyle(QFrame::NoFrame);
-      ui.view->setBackgroundBrush(QBrush(settings.fullScreenBgColor()));
-      ui.view->updateOutline();
+      ui.view->setViewBackground(QBrush(settings.fullScreenBgColor()), ui.actionSolidBg->isChecked());
       ui.toolBar->hide();
       ui.annotationsToolBar->hide();
       ui.statusBar->hide();
@@ -1545,8 +1549,7 @@ void MainWindow::changeEvent(QEvent* event) {
     }
     else { // restore to normal window mode
       ui.view->setFrameStyle(QFrame::StyledPanel|QFrame::Sunken);
-      ui.view->setBackgroundBrush(QBrush(settings.bgColor()));
-      ui.view->updateOutline();
+      ui.view->setViewBackground(QBrush(settings.bgColor()), ui.actionSolidBg->isChecked());
       if(ui.actionMenubar->isChecked()) {
         on_actionMenubar_triggered(true);
       }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -122,6 +122,7 @@ private Q_SLOTS:
   void on_actionUpload_triggered();
 
   void on_actionShowThumbnails_triggered(bool checked);
+  void on_actionSolidBg_triggered(bool checked);
   void on_actionShowOutline_triggered(bool checked);
   void on_actionShowExifData_triggered(bool checked);
   void on_actionFullScreen_triggered(bool checked);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -136,6 +136,7 @@
     <addaction name="actionOriginalSize"/>
     <addaction name="actionZoomFit"/>
     <addaction name="separator"/>
+    <addaction name="actionSolidBg"/>
     <addaction name="actionShowThumbnails"/>
     <addaction name="actionShowOutline"/>
     <addaction name="actionShowExifData"/>
@@ -835,6 +836,17 @@
   <action name="actionLastFrame">
    <property name="text">
     <string>Last Frame</string>
+   </property>
+  </action>
+  <action name="actionSolidBg">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Solid Background</string>
    </property>
   </action>
  </widget>

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -82,6 +82,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
   ui.fullScreenBgColor->setColor(settings.fullScreenBgColor());
   ui.maxRecentFiles->setValue(settings.maxRecentFiles());
   ui.slideShowInterval->setValue(settings.slideShowInterval());
+  ui.solidBgBox->setChecked(settings.solidBg());
   ui.oulineBox->setChecked(settings.isOutlineShown());
   ui.menubarBox->setChecked(settings.isMenubarShown());
   ui.toolbarBox->setChecked(settings.isToolbarShown());
@@ -155,6 +156,7 @@ void PreferencesDialog::accept() {
   settings.setFullScreenBgColor(ui.fullScreenBgColor->color());
   settings.setMaxRecentFiles(ui.maxRecentFiles->value());
   settings.setSlideShowInterval(ui.slideShowInterval->value());
+  settings.setSolidBg(ui.solidBgBox->isChecked());
   settings.showOutline(ui.oulineBox->isChecked());
   settings.showMenubar(ui.menubarBox->isChecked());
   settings.showToolbar(ui.toolbarBox->isChecked());

--- a/src/preferencesdialog.ui
+++ b/src/preferencesdialog.ui
@@ -80,7 +80,7 @@
        <item row="3" column="1">
         <widget class="QComboBox" name="thumbnailSizeComboBox"/>
        </item>
-       <item row="4" column="0">
+       <item row="4" column="0" colspan="2">
         <widget class="QCheckBox" name="useTrashBox">
          <property name="text">
           <string>Use system Trash (and do not prompt)</string>
@@ -107,28 +107,28 @@
        <item row="0" column="1">
         <widget class="QComboBox" name="thumbnailsPositionComboBox"/>
        </item>
-       <item row="1" column="0">
+       <item row="1" column="0" colspan="2">
         <widget class="QCheckBox" name="exifDataBox">
          <property name="text">
           <string>Show Exif data dock by default</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="2" column="0" colspan="2">
         <widget class="QCheckBox" name="menubarBox">
          <property name="text">
           <string>Show menubar by default</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="3" column="0" colspan="2">
         <widget class="QCheckBox" name="toolbarBox">
          <property name="text">
           <string>Show main toolbar by default</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="4" column="0" colspan="2">
         <widget class="QCheckBox" name="annotationBox">
          <property name="text">
           <string>Show annotations toolbar by default</string>
@@ -236,21 +236,28 @@ Reload current image to see the effect.</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="4" column="0" colspan="2">
+        <widget class="QCheckBox" name="solidBgBox">
+         <property name="text">
+          <string>Solid background by default</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
         <widget class="QCheckBox" name="oulineBox">
          <property name="text">
           <string>Show image outline by default</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0" colspan="2">
         <widget class="QCheckBox" name="forceZoomFitBox">
          <property name="text">
           <string>Fit images when navigating</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0" colspan="2">
         <widget class="QCheckBox" name="smoothOnZoomBox">
          <property name="text">
           <string>Smooth images on zooming</string>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -30,6 +30,7 @@ inline static Fm::FolderModel::ColumnId sortColumnFromString(const QString& str)
 
 Settings::Settings():
   useFallbackIconTheme_(QIcon::themeName().isEmpty() || QIcon::themeName() == QLatin1String("hicolor")),
+  solidBg_(true),
   bgColor_(255, 255, 255),
   fullScreenBgColor_(0, 0, 0),
   showExifData_(false),
@@ -64,6 +65,7 @@ Settings::~Settings() {
 bool Settings::load() {
   QSettings settings(QStringLiteral("lximage-qt"), QStringLiteral("settings"));
   fallbackIconTheme_ = settings.value(QStringLiteral("fallbackIconTheme"), fallbackIconTheme_).toString();
+  solidBg_ = settings.value(QStringLiteral("solidBg"), true).toBool();
   bgColor_ = settings.value(QStringLiteral("bgColor"), bgColor_).value<QColor>();
   fullScreenBgColor_ = settings.value(QStringLiteral("fullScreenBgColor"), fullScreenBgColor_).value<QColor>();
   // showSidePane_;
@@ -115,6 +117,7 @@ bool Settings::save() {
   QSettings settings(QStringLiteral("lximage-qt"), QStringLiteral("settings"));
 
   settings.setValue(QStringLiteral("fallbackIconTheme"), fallbackIconTheme_);
+  settings.setValue(QStringLiteral("solidBg"), solidBg_);
   settings.setValue(QStringLiteral("bgColor"), bgColor_);
   settings.setValue(QStringLiteral("fullScreenBgColor"), fullScreenBgColor_);
   settings.setValue(QStringLiteral("slideShowInterval"), slideShowInterval_);

--- a/src/settings.h
+++ b/src/settings.h
@@ -51,6 +51,13 @@ public:
     fallbackIconTheme_ = value;
   }
 
+  bool solidBg() const {
+    return solidBg_;
+  }
+  void setSolidBg(bool solidBg) {
+    solidBg_ = solidBg;
+  }
+
   QColor bgColor() const {
     return bgColor_;
   }
@@ -286,6 +293,7 @@ private:
 
 private:
   bool useFallbackIconTheme_;
+  bool solidBg_;
   QColor bgColor_;
   QColor fullScreenBgColor_;
   bool showExifData_;


### PR DESCRIPTION
It's especially useful for checking the translucent parts of images that support translucency.

The user can set it temporarily by toggling its action in "View" → "Solid Background" (its shortcut can be defined in the shortcut editor) or change the default by toggling its new option in Preferences → Image.

Closes https://github.com/lxqt/lximage-qt/issues/192