### PR TITLE
Set window icon

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -37,6 +37,7 @@ Application::Application(int& argc, char** argv):
   libFm(),
   windowCount_(0) {
   setApplicationVersion(QStringLiteral(LXIMAGE_VERSION));
+  setWindowIcon(QIcon::fromTheme(QStringLiteral("lximage-qt")));
 }
 
 bool Application::init(int argc, char** argv) {


### PR DESCRIPTION
This ensures that the icon is set on all windows on X11.

Similar to https://github.com/lxqt/pcmanfm-qt/pull/2096, the non-modal preferences window has no icon on X11 without this.